### PR TITLE
Use positional keyboard mapping instead of symbolic in the SDL2 frontend

### DIFF
--- a/platform/rustboyadvance-sdl2/src/input.rs
+++ b/platform/rustboyadvance-sdl2/src/input.rs
@@ -1,4 +1,4 @@
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::Scancode;
 
 use rustboyadvance_core::keypad as gba_keypad;
 use rustboyadvance_core::InputInterface;
@@ -17,30 +17,30 @@ impl InputInterface for Sdl2Input {
 }
 
 impl Sdl2Input {
-    pub fn on_keyboard_key_down(&mut self, keycode: Keycode) {
-        if let Some(key) = keycode_to_keypad(keycode) {
+    pub fn on_keyboard_key_down(&mut self, scancode: Scancode) {
+        if let Some(key) = scancode_to_keypad(scancode) {
             self.keyinput.set_bit(key as usize, false);
         }
     }
-    pub fn on_keyboard_key_up(&mut self, keycode: Keycode) {
-        if let Some(key) = keycode_to_keypad(keycode) {
+    pub fn on_keyboard_key_up(&mut self, scancode: Scancode) {
+        if let Some(key) = scancode_to_keypad(scancode) {
             self.keyinput.set_bit(key as usize, true);
         }
     }
 }
 
-fn keycode_to_keypad(keycode: Keycode) -> Option<gba_keypad::Keys> {
-    match keycode {
-        Keycode::Up => Some(gba_keypad::Keys::Up),
-        Keycode::Down => Some(gba_keypad::Keys::Down),
-        Keycode::Left => Some(gba_keypad::Keys::Left),
-        Keycode::Right => Some(gba_keypad::Keys::Right),
-        Keycode::Z => Some(gba_keypad::Keys::ButtonB),
-        Keycode::X => Some(gba_keypad::Keys::ButtonA),
-        Keycode::Return => Some(gba_keypad::Keys::Start),
-        Keycode::Backspace => Some(gba_keypad::Keys::Select),
-        Keycode::A => Some(gba_keypad::Keys::ButtonL),
-        Keycode::S => Some(gba_keypad::Keys::ButtonR),
+fn scancode_to_keypad(scancode: Scancode) -> Option<gba_keypad::Keys> {
+    match scancode {
+        Scancode::Up => Some(gba_keypad::Keys::Up),
+        Scancode::Down => Some(gba_keypad::Keys::Down),
+        Scancode::Left => Some(gba_keypad::Keys::Left),
+        Scancode::Right => Some(gba_keypad::Keys::Right),
+        Scancode::Z => Some(gba_keypad::Keys::ButtonB),
+        Scancode::X => Some(gba_keypad::Keys::ButtonA),
+        Scancode::Return => Some(gba_keypad::Keys::Start),
+        Scancode::Backspace => Some(gba_keypad::Keys::Select),
+        Scancode::A => Some(gba_keypad::Keys::ButtonL),
+        Scancode::S => Some(gba_keypad::Keys::ButtonR),
         _ => None,
     }
 }

--- a/platform/rustboyadvance-sdl2/src/main.rs
+++ b/platform/rustboyadvance-sdl2/src/main.rs
@@ -1,7 +1,7 @@
 use sdl2;
 use sdl2::event::Event;
 use sdl2::image::{InitFlag, LoadTexture};
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::Scancode;
 use sdl2::messagebox::*;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -255,18 +255,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         for event in event_pump.poll_iter() {
             match event {
                 Event::KeyDown {
-                    keycode: Some(keycode),
+                    scancode: Some(scancode),
                     ..
-                } => match keycode {
-                    Keycode::Space => frame_limiter = false,
+                } => match scancode {
+                    Scancode::Space => frame_limiter = false,
                     k => input.borrow_mut().on_keyboard_key_down(k),
                 },
                 Event::KeyUp {
-                    keycode: Some(keycode),
+                    scancode: Some(scancode),
                     ..
-                } => match keycode {
+                } => match scancode {
                     #[cfg(feature = "debugger")]
-                    Keycode::F1 => {
+                    Scancode::F1 => {
                         let mut debugger = Debugger::new(gba);
                         info!("starting debugger...");
                         debugger.repl(matches.value_of("script_file")).unwrap();
@@ -274,8 +274,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         info!("ending debugger...")
                     }
                     #[cfg(feature = "gdb")]
-                    Keycode::F2 => spawn_and_run_gdb_server(&mut gba, DEFAULT_GDB_SERVER_ADDR)?,
-                    Keycode::F5 => {
+                    Scancode::F2 => spawn_and_run_gdb_server(&mut gba, DEFAULT_GDB_SERVER_ADDR)?,
+                    Scancode::F5 => {
                         info!("Saving state ...");
                         let save = gba.save_state()?;
                         write_bin_file(&savestate_path, &save)?;
@@ -285,7 +285,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             bytesize::ByteSize::b(save.len() as u64)
                         );
                     }
-                    Keycode::F9 => {
+                    Scancode::F9 => {
                         if savestate_path.is_file() {
                             let save = read_bin_file(&savestate_path)?;
                             info!("Restoring state from {:?}...", savestate_path);
@@ -295,7 +295,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             info!("Savestate not created, please create one by pressing F5");
                         }
                     }
-                    Keycode::Space => frame_limiter = true,
+                    Scancode::Space => frame_limiter = true,
                     k => input.borrow_mut().on_keyboard_key_up(k),
                 },
                 Event::Quit { .. } => break 'running,


### PR DESCRIPTION
After this pull request RustBoyAdvance-NG no longer induces RSI/carpal tunnel syndrome on your Central European users using QWERTZ keyboards.

Rationale behind this change as per the SDL documentation:

https://wiki.libsdl.org/CategoryKeyboard
> ... scancodes are suited in situations where controls are layout-dependent (eg. the "WASD" keys as left-handed arrow keys), whereas keycodes are better suited to situations where controls are character-dependent (eg. the "I" key for Inventory).