### PR TITLE
Implement joystick and gamepad support for the SDL2 frontend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/gba-suite"]
 	path = external/gba-suite
 	url = https://github.com/jsmolka/gba-suite.git
+[submodule "external/SDL_GameControllerDB"]
+	path = external/SDL_GameControllerDB
+	url = https://github.com/gabomdq/SDL_GameControllerDB

--- a/platform/rustboyadvance-sdl2/src/input.rs
+++ b/platform/rustboyadvance-sdl2/src/input.rs
@@ -1,4 +1,5 @@
 use sdl2::keyboard::Scancode;
+use sdl2::controller::Button;
 
 use rustboyadvance_core::keypad as gba_keypad;
 use rustboyadvance_core::InputInterface;
@@ -22,8 +23,21 @@ impl Sdl2Input {
             self.keyinput.set_bit(key as usize, false);
         }
     }
+
     pub fn on_keyboard_key_up(&mut self, scancode: Scancode) {
         if let Some(key) = scancode_to_keypad(scancode) {
+            self.keyinput.set_bit(key as usize, true);
+        }
+    }
+
+    pub fn on_controller_button_down(&mut self, button: Button) {
+        if let Some(key) = controller_button_to_keypad(button) {
+            self.keyinput.set_bit(key as usize, false);
+        }
+    }
+
+    pub fn on_controller_button_up(&mut self, button: Button) {
+        if let Some(key) = controller_button_to_keypad(button) {
             self.keyinput.set_bit(key as usize, true);
         }
     }
@@ -41,6 +55,22 @@ fn scancode_to_keypad(scancode: Scancode) -> Option<gba_keypad::Keys> {
         Scancode::Backspace => Some(gba_keypad::Keys::Select),
         Scancode::A => Some(gba_keypad::Keys::ButtonL),
         Scancode::S => Some(gba_keypad::Keys::ButtonR),
+        _ => None,
+    }
+}
+
+fn controller_button_to_keypad(button: Button) -> Option<gba_keypad::Keys> {
+    match button {
+        Button::DPadUp => Some(gba_keypad::Keys::Up),
+        Button::DPadDown => Some(gba_keypad::Keys::Down),
+        Button::DPadLeft => Some(gba_keypad::Keys::Left),
+        Button::DPadRight => Some(gba_keypad::Keys::Right),
+        Button::A => Some(gba_keypad::Keys::ButtonB), // A and B are swapped compared to the SDL layout
+        Button::B => Some(gba_keypad::Keys::ButtonA),
+        Button::Start => Some(gba_keypad::Keys::Start),
+        Button::Back => Some(gba_keypad::Keys::Select),
+        Button::LeftShoulder => Some(gba_keypad::Keys::ButtonL),
+        Button::RightShoulder => Some(gba_keypad::Keys::ButtonR),
         _ => None,
     }
 }


### PR DESCRIPTION
The button layout is hardcoded at the moment due to the lack of an emulator config file.

Tested with:
* Trust GXT-530 (`0e8f:0003 GreenAsia Inc. MaxFire Blaze2`)
* Manta Maverick MM603 (`0583:a00b Padix Co., Ltd (Rockfire)`)