### PR TITLE
Arm use const generics

### DIFF
--- a/bindings/rustboyadvance-jni/Cargo.toml
+++ b/bindings/rustboyadvance-jni/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-rustboyadvance-core = {path = "../../core/", features = ["arm7tdmi_dispatch_table", "no_video_interface"]}
+rustboyadvance-core = {path = "../../core/", features = ["no_video_interface"]}
 jni = "0.17.0"
 log = {version = "0.4.8", features = ["release_max_level_info", "max_level_debug"]}
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,12 +57,9 @@ name = "performance"
 harness = false
 
 [features]
-default = ["arm7tdmi_dispatch_table"]
+default = []
 elf_support = ["goblin"]
 debugger = ["nom", "rustyline", "fuzzy-matcher", "elf_support"]
 gdb = ["gdbstub"]
-# Uses lookup tables when executing instructions instead of `match` statements.
-# Faster, but consumes more memory.
-arm7tdmi_dispatch_table = []
 # For use for ports where VideoInterface is not needed like wasm & jni
 no_video_interface = []

--- a/core/build.rs
+++ b/core/build.rs
@@ -62,14 +62,31 @@ fn thumb_decode(i: u16) -> (&'static str, String) {
     } else if i & 0xf200 == 0x5000 {
         (
             "LdrStrRegOffset",
-            String::from("exec_thumb_ldr_str_reg_offset"),
+            format!(
+                "exec_thumb_ldr_str_reg_offset::<{LOAD}, {RO}, {BYTE}>",
+                LOAD = i.bit(11),
+                RO = i.bit_range(6..9) as usize,
+                BYTE = i.bit(10),
+            ),
         )
     } else if i & 0xf200 == 0x5200 {
         ("LdrStrSHB", String::from("exec_thumb_ldr_str_shb"))
     } else if i & 0xe000 == 0x6000 {
+        let is_transferring_bytes = i.bit(12);
+        let offset5 = i.bit_range(6..11) as u8;
+        let offset = if is_transferring_bytes {
+            offset5
+        } else {
+            (offset5 << 3) >> 1
+        };
         (
             "LdrStrImmOffset",
-            String::from("exec_thumb_ldr_str_imm_offset"),
+            format!(
+                "exec_thumb_ldr_str_imm_offset::<{LOAD}, {BYTE}, {OFFSET}>",
+                LOAD = i.bit(11),
+                BYTE = is_transferring_bytes,
+                OFFSET = offset
+            ),
         )
     } else if i & 0xf000 == 0x8000 {
         (

--- a/core/build.rs
+++ b/core/build.rs
@@ -305,10 +305,10 @@ fn arm_decode(i: u32) -> (&'static str, String) {
                         let is_op_not_touching_rd = i.bit_range(21..25) & 0b1100 == 0b1000;
                         if !set_cond_flags && is_op_not_touching_rd {
                             if i.bit(21) {
-                                // Since bit-16 is ignored and we can't know statically if this is a exec_arm_transfer_to_status or exec_arm_transfer_to_status
-                                ("MoveToStatus", String::from("exec_arm_transfer_to_status"))
+                                ("MoveToStatus", format!("exec_arm_transfer_to_status::<{IMM}, {SPSR_FLAG}>",
+                                    IMM = i.bit(25), SPSR_FLAG = i.bit(22)))
                             } else {
-                                ("MoveFromStatus", String::from("exec_arm_mrs"))
+                                ("MoveFromStatus", format!("exec_arm_mrs::<{SPSR_FLAG}>", SPSR_FLAG = i.bit(22)))
                             }
                         } else {
                             ("DataProcessing", format!("exec_arm_data_processing::<{OP}, {IMM}, {SET_FLAGS}, {SHIFT_BY_REG}>",

--- a/core/build.rs
+++ b/core/build.rs
@@ -272,10 +272,32 @@ fn arm_decode(i: u32) -> (&'static str, String) {
                 _ => None,
             };
 
-            result.unwrap_or_else(|| {
+            if let Some(result) = result {
+                result
+            } else {
                 match (i.ibit(25), i.ibit(22), i.ibit(7), i.ibit(4)) {
-                    (0, 0, 1, 1) => ("HalfwordDataTransferRegOffset", String::from("exec_arm_ldr_str_hs_reg")),
-                    (0, 1, 1, 1) => ("HalfwordDataTransferImmediateOffset", String::from("exec_arm_ldr_str_hs_imm")),
+                    (0, 0, 1, 1) => (
+                        "HalfwordDataTransferRegOffset",
+                        format!(
+                            "exec_arm_ldr_str_hs_reg::<{HS}, {LOAD}, {WRITEBACK}, {PRE_INDEX}, {ADD}>",
+                            HS = (i & 0b1100000) >> 5,
+                            LOAD = i.bit(20),
+                            WRITEBACK = i.bit(21),
+                            ADD = i.bit(23),
+                            PRE_INDEX = i.bit(24),
+                        ),
+                    ),
+                    (0, 1, 1, 1) => (
+                        "HalfwordDataTransferImmediateOffset",
+                        format!(
+                            "exec_arm_ldr_str_hs_imm::<{HS}, {LOAD}, {WRITEBACK}, {PRE_INDEX}, {ADD}>",
+                            HS = (i & 0b1100000) >> 5,
+                            LOAD = i.bit(20),
+                            WRITEBACK = i.bit(21),
+                            ADD = i.bit(23),
+                            PRE_INDEX = i.bit(24)
+                        ),
+                    ),
                     _ => {
                         let set_cond_flags = i.bit(20);
                         // PSR Transfers are encoded as a subset of Data Processing,
@@ -297,7 +319,7 @@ fn arm_decode(i: u32) -> (&'static str, String) {
                         }
                     }
                 }
-            })
+            }
         }
         0b01 => {
             match (i.bit(25), i.bit(4)) {

--- a/core/build.rs
+++ b/core/build.rs
@@ -338,7 +338,17 @@ fn arm_decode(i: u32) -> (&'static str, String) {
             }
         }
         0b10 => match i.bit(25) {
-            F => ("BlockDataTransfer", String::from("exec_arm_ldm_stm")),
+            F => (
+                "BlockDataTransfer",
+                format!(
+                    "exec_arm_ldm_stm::<{LOAD}, {WRITEBACK}, {FLAG_S}, {ADD}, {PRE_INDEX}>",
+                    LOAD = i.bit(20),
+                    WRITEBACK = i.bit(21),
+                    FLAG_S = i.bit(22),
+                    ADD = i.bit(23),
+                    PRE_INDEX = i.bit(24),
+                ),
+            ),
             T => (
                 "BranchLink",
                 format!("exec_arm_b_bl::<{LINK}>", LINK = i.bit(24)),

--- a/core/build.rs
+++ b/core/build.rs
@@ -44,10 +44,21 @@ fn thumb_decode(i: u16) -> (&'static str, String) {
     } else if i & 0xfc00 == 0x4400 {
         (
             "HiRegOpOrBranchExchange",
-            String::from("exec_thumb_hi_reg_op_or_bx"),
+            format!(
+                "exec_thumb_hi_reg_op_or_bx::<{OP}, {FLAG_H1}, {FLAG_H2}>",
+                OP = i.bit_range(8..10) as u8,
+                FLAG_H1 = i.bit(7),
+                FLAG_H2 = i.bit(6),
+            ),
         )
     } else if i & 0xf800 == 0x4800 {
-        ("LdrPc", String::from("exec_thumb_ldr_pc"))
+        (
+            "LdrPc",
+            format!(
+                "exec_thumb_ldr_pc::<{RD}>",
+                RD = i.bit_range(8..11) as usize
+            ),
+        )
     } else if i & 0xf200 == 0x5000 {
         (
             "LdrStrRegOffset",

--- a/core/build.rs
+++ b/core/build.rs
@@ -231,15 +231,33 @@ fn arm_decode(i: u32) -> (&'static str, String) {
             let result = match (i.bit_range(23..26), i.bit_range(4..8)) {
                 (0b000, 0b1001) => {
                     if 0b0 == i.ibit(22) {
-                        Some(("Multiply", String::from("exec_arm_mul_mla")))
+                        Some((
+                            "Multiply",
+                            format!(
+                                "exec_arm_mul_mla::<{UPDATE_FLAGS}, {ACCUMULATE}>",
+                                UPDATE_FLAGS = i.bit(20),
+                                ACCUMULATE = i.bit(21),
+                            ),
+                        ))
                     } else {
                         None
                     }
                 }
-                (0b001, 0b1001) => Some(("MultiplyLong", String::from("exec_arm_mull_mlal"))),
+                (0b001, 0b1001) => Some((
+                    "MultiplyLong",
+                    format!(
+                        "exec_arm_mull_mlal::<{UPDATE_FLAGS}, {ACCUMULATE}, {U_FLAG}>",
+                        UPDATE_FLAGS = i.bit(20),
+                        ACCUMULATE = i.bit(21),
+                        U_FLAG = i.bit(22),
+                    ),
+                )),
                 (0b010, 0b1001) => {
                     if 0b00 == i.bit_range(20..22) {
-                        Some(("SingleDataSwap", String::from("exec_arm_swp")))
+                        Some((
+                            "SingleDataSwap",
+                            format!("exec_arm_swp::<{BYTE}>", BYTE = i.bit(22)),
+                        ))
                     } else {
                         None
                     }

--- a/core/build.rs
+++ b/core/build.rs
@@ -162,7 +162,17 @@ fn arm_decode(i: u32) -> String {
         }
         0b01 => {
             match (i.bit(25), i.bit(4)) {
-                (_, F) | (F, T) => String::from("exec_arm_ldr_str"),
+                (_, F) | (F, T) => format!(
+                    "exec_arm_ldr_str::<{LOAD}, {WRITEBACK}, {PRE_INDEX}, {BYTE}, {SHIFT}, {ADD}, {BS_OP}, {SHIFT_BY_REG}>",
+                    LOAD = i.bit(20),
+                    WRITEBACK = i.bit(21),
+                    BYTE = i.bit(22),
+                    ADD = i.bit(23),
+                    PRE_INDEX = i.bit(24),
+                    SHIFT = i.bit(25),
+                    BS_OP = i.bit_range(5..7) as u8,
+                    SHIFT_BY_REG = i.bit(4),
+                ),
                 (T, T) => String::from("arm_undefined"), /* Possible ARM11 but we don't implement these */
             }
         }

--- a/core/build.rs
+++ b/core/build.rs
@@ -420,20 +420,15 @@ fn generate_arm_lut(file: &mut fs::File) -> Result<(), std::io::Error> {
 }
 
 fn main() {
-    let arm7tdmi_dispatch_table_enabled =
-        env::var_os("CARGO_FEATURE_ARM7TDMI_DISPATCH_TABLE").is_some();
+    // TODO - don't do this in the build script and use `const fn` instead when it becomes stable
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let thumb_lut_path = Path::new(&out_dir).join("thumb_lut.rs");
+    let mut thumb_lut_file = fs::File::create(&thumb_lut_path).expect("failed to create file");
+    generate_thumb_lut(&mut thumb_lut_file).expect("failed to generate thumb table");
 
-    if arm7tdmi_dispatch_table_enabled {
-        // TODO - don't do this in the build script and use `const fn` instead when it becomes stable
-        let out_dir = env::var_os("OUT_DIR").unwrap();
-        let thumb_lut_path = Path::new(&out_dir).join("thumb_lut.rs");
-        let mut thumb_lut_file = fs::File::create(&thumb_lut_path).expect("failed to create file");
-        generate_thumb_lut(&mut thumb_lut_file).expect("failed to generate thumb table");
+    let arm_lut_path = Path::new(&out_dir).join("arm_lut.rs");
+    let mut arm_lut_file = fs::File::create(&arm_lut_path).expect("failed to create file");
+    generate_arm_lut(&mut arm_lut_file).expect("failed to generate arm table");
 
-        let arm_lut_path = Path::new(&out_dir).join("arm_lut.rs");
-        let mut arm_lut_file = fs::File::create(&arm_lut_path).expect("failed to create file");
-        generate_arm_lut(&mut arm_lut_file).expect("failed to generate arm table");
-
-        println!("cargo:rerun-if-changed=build.rs");
-    }
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/core/build.rs
+++ b/core/build.rs
@@ -30,10 +30,17 @@ fn thumb_decode(i: u16) -> (&'static str, String) {
     } else if i & 0xe000 == 0x2000 {
         (
             "DataProcessImm",
-            String::from("exec_thumb_data_process_imm"),
+            format!(
+                "exec_thumb_data_process_imm::<{OP}, {RD}>",
+                OP = i.bit_range(11..13) as u8,
+                RD = i.bit_range(8..11)
+            ),
         )
     } else if i & 0xfc00 == 0x4000 {
-        ("AluOps", String::from("exec_thumb_alu_ops"))
+        (
+            "AluOps",
+            format!("exec_thumb_alu_ops::<{OP}>", OP = i.bit_range(6..10) as u16),
+        )
     } else if i & 0xfc00 == 0x4400 {
         (
             "HiRegOpOrBranchExchange",

--- a/core/src/arm7tdmi/alu.rs
+++ b/core/src/arm7tdmi/alu.rs
@@ -272,7 +272,7 @@ impl<I: MemoryInterface> Core<I> {
             1 => BarrelShiftOpCode::LSR,
             2 => BarrelShiftOpCode::ASR,
             3 => BarrelShiftOpCode::ROR,
-            _ => unreachable!(),
+            _ => unsafe { std::hint::unreachable_unchecked() },
         };
         if SHIFT_BY_REG {
             let rs = offset.bit_range(8..12) as usize;

--- a/core/src/arm7tdmi/alu.rs
+++ b/core/src/arm7tdmi/alu.rs
@@ -261,6 +261,28 @@ impl<I: MemoryInterface> Core<I> {
         self.barrel_shift_op(bs_op, val, amount, carry, false)
     }
 
+    pub fn register_shift_const<const BS_OP: u8, const SHIFT_BY_REG: bool>(
+        &mut self,
+        offset: u32,
+        reg: usize,
+        carry: &mut bool,
+    ) -> u32 {
+        let op = match BS_OP {
+            0 => BarrelShiftOpCode::LSL,
+            1 => BarrelShiftOpCode::LSR,
+            2 => BarrelShiftOpCode::ASR,
+            3 => BarrelShiftOpCode::ROR,
+            _ => unreachable!(),
+        };
+        if SHIFT_BY_REG {
+            let rs = offset.bit_range(8..12) as usize;
+            self.shift_by_register(op, reg, rs, carry)
+        } else {
+            let amount = offset.bit_range(7..12) as u32;
+            self.barrel_shift_op(op, self.get_reg(reg), amount, carry, true)
+        }
+    }
+
     pub fn register_shift(&mut self, shift: &ShiftedRegister, carry: &mut bool) -> u32 {
         match shift.shift_by {
             ShiftRegisterBy::ByAmount(amount) => {

--- a/core/src/arm7tdmi/alu.rs
+++ b/core/src/arm7tdmi/alu.rs
@@ -3,7 +3,7 @@ use bit::BitIndex;
 use super::memory::MemoryInterface;
 use super::{Core, REG_PC};
 
-#[derive(Debug, Primitive, PartialEq)]
+#[derive(Debug, Primitive, Eq, PartialEq)]
 pub enum AluOpCode {
     AND = 0b0000,
     EOR = 0b0001,

--- a/core/src/arm7tdmi/arm/exec.rs
+++ b/core/src/arm7tdmi/arm/exec.rs
@@ -12,27 +12,6 @@ use super::ArmDecodeHelper;
 use super::*;
 
 impl<I: MemoryInterface> Core<I> {
-    #[cfg(not(feature = "arm7tdmi_dispatch_table"))]
-    pub fn exec_arm(&mut self, insn: u32, fmt: ArmFormat) -> CpuAction {
-        match fmt {
-            ArmFormat::BranchExchange => self.exec_arm_bx(insn),
-            ArmFormat::BranchLink => self.exec_arm_b_bl(insn),
-            ArmFormat::DataProcessing => self.exec_arm_data_processing(insn),
-            ArmFormat::SoftwareInterrupt => self.exec_arm_swi(insn),
-            ArmFormat::SingleDataTransfer => self.exec_arm_ldr_str(insn),
-            ArmFormat::HalfwordDataTransferImmediateOffset => self.exec_arm_ldr_str_hs_imm(insn),
-            ArmFormat::HalfwordDataTransferRegOffset => self.exec_arm_ldr_str_hs_reg(insn),
-            ArmFormat::BlockDataTransfer => self.exec_arm_ldm_stm(insn),
-            ArmFormat::MoveFromStatus => self.exec_arm_mrs(insn),
-            ArmFormat::MoveToStatus => self.exec_arm_transfer_to_status(insn),
-            ArmFormat::MoveToFlags => self.exec_arm_transfer_to_status(insn),
-            ArmFormat::Multiply => self.exec_arm_mul_mla(insn),
-            ArmFormat::MultiplyLong => self.exec_arm_mull_mlal(insn),
-            ArmFormat::SingleDataSwap => self.exec_arm_swp(insn),
-            ArmFormat::Undefined => self.arm_undefined(insn),
-        }
-    }
-
     pub fn arm_undefined(&mut self, insn: u32) -> CpuAction {
         panic!(
             "executing undefined arm instruction {:08x} at @{:08x}",

--- a/core/src/arm7tdmi/cpu.rs
+++ b/core/src/arm7tdmi/cpu.rs
@@ -367,7 +367,7 @@ impl<I: MemoryInterface> Core<I> {
     cfg_if! {
         if #[cfg(feature = "arm7tdmi_dispatch_table")] {
             fn step_arm_exec(&mut self, insn: u32) -> CpuAction {
-                let hash = (((insn >> 16) & 0xff0) | ((insn >> 4) & 0x00f)) as usize;
+                let hash = (((insn >> 16) & 0xff0) | ((insn >> 4) & 0xf)) as usize;
                 let arm_info = &Self::ARM_LUT[hash];
                 #[cfg(feature = "debugger")]
                 self.debugger_record_step(DecodedInstruction::Arm(ArmInstruction::new(

--- a/core/src/arm7tdmi/cpu.rs
+++ b/core/src/arm7tdmi/cpu.rs
@@ -113,11 +113,11 @@ impl Default for DebuggerState {
 
 #[derive(Clone, Debug)]
 pub struct Core<I: MemoryInterface> {
+    pub pc: u32,
     pub(super) bus: Shared<I>,
 
     next_fetch_access: MemoryAccess,
     pipeline: [u32; 2],
-    pub pc: u32,
     pub gpr: [u32; 15],
 
     pub cpsr: RegPSR,

--- a/core/src/arm7tdmi/thumb/disass.rs
+++ b/core/src/arm7tdmi/thumb/disass.rs
@@ -7,6 +7,18 @@ use crate::arm7tdmi::*;
 
 use super::ThumbDecodeHelper;
 
+pub(super) mod consts {
+    pub(super) mod flags {
+        pub const FLAG_H1: usize = 7;
+        pub const FLAG_H2: usize = 6;
+        pub const FLAG_R: usize = 8;
+        pub const FLAG_LOW_OFFSET: usize = 11;
+        pub const FLAG_SP: usize = 11;
+        pub const FLAG_SIGN_EXTEND: usize = 10;
+        pub const FLAG_HALFWORD: usize = 11;
+    }
+}
+
 impl ThumbInstruction {
     fn fmt_thumb_move_shifted_reg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/core/src/arm7tdmi/thumb/exec.rs
+++ b/core/src/arm7tdmi/thumb/exec.rs
@@ -575,30 +575,4 @@ impl<I: MemoryInterface> Core<I> {
             self.pc_thumb()
         )
     }
-
-    #[cfg(not(feature = "arm7tdmi_dispatch_table"))]
-    pub fn exec_thumb(&mut self, insn: u16, fmt: ThumbFormat) -> CpuAction {
-        match fmt {
-            ThumbFormat::MoveShiftedReg => self.exec_thumb_move_shifted_reg(insn),
-            ThumbFormat::AddSub => self.exec_thumb_add_sub(insn),
-            ThumbFormat::DataProcessImm => self.exec_thumb_data_process_imm(insn),
-            ThumbFormat::AluOps => self.exec_thumb_alu_ops(insn),
-            ThumbFormat::HiRegOpOrBranchExchange => self.exec_thumb_hi_reg_op_or_bx(insn),
-            ThumbFormat::LdrPc => self.exec_thumb_ldr_pc(insn),
-            ThumbFormat::LdrStrRegOffset => self.exec_thumb_ldr_str_reg_offset(insn),
-            ThumbFormat::LdrStrSHB => self.exec_thumb_ldr_str_shb(insn),
-            ThumbFormat::LdrStrImmOffset => self.exec_thumb_ldr_str_imm_offset(insn),
-            ThumbFormat::LdrStrHalfWord => self.exec_thumb_ldr_str_halfword(insn),
-            ThumbFormat::LdrStrSp => self.exec_thumb_ldr_str_sp(insn),
-            ThumbFormat::LoadAddress => self.exec_thumb_load_address(insn),
-            ThumbFormat::AddSp => self.exec_thumb_add_sp(insn),
-            ThumbFormat::PushPop => self.exec_thumb_push_pop(insn),
-            ThumbFormat::LdmStm => self.exec_thumb_ldm_stm(insn),
-            ThumbFormat::BranchConditional => self.exec_thumb_branch_with_cond(insn),
-            ThumbFormat::Swi => self.exec_thumb_swi(insn),
-            ThumbFormat::Branch => self.exec_thumb_branch(insn),
-            ThumbFormat::BranchLongWithLink => self.exec_thumb_branch_long_with_link(insn),
-            ThumbFormat::Undefined => self.thumb_undefined(insn),
-        }
-    }
 }

--- a/core/src/arm7tdmi/thumb/mod.rs
+++ b/core/src/arm7tdmi/thumb/mod.rs
@@ -208,21 +208,6 @@ impl From<OpFormat5> for AluOpCode {
     }
 }
 
-pub(super) mod consts {
-    pub(super) mod flags {
-        #[cfg(feature = "debugger")]
-        pub const FLAG_H1: usize = 7;
-        #[cfg(feature = "debugger")]
-        pub const FLAG_H2: usize = 6;
-        pub const FLAG_R: usize = 8;
-        pub const FLAG_S: usize = 7;
-        pub const FLAG_LOW_OFFSET: usize = 11;
-        pub const FLAG_SP: usize = 11;
-        pub const FLAG_SIGN_EXTEND: usize = 10;
-        pub const FLAG_HALFWORD: usize = 11;
-    }
-}
-
 /// A trait which provides methods to extract thumb instruction fields
 pub trait ThumbDecodeHelper {
     // Consts
@@ -367,7 +352,7 @@ macro_rules! thumb_decode_helper_impl {
             #[inline]
             fn sword7(&self) -> i32 {
                 let imm7 = *self & 0x7f;
-                if self.bit(consts::flags::FLAG_S) {
+                if self.bit(7) {
                     -((imm7 << 2) as i32)
                 } else {
                     (imm7 << 2) as i32

--- a/core/src/arm7tdmi/thumb/mod.rs
+++ b/core/src/arm7tdmi/thumb/mod.rs
@@ -210,7 +210,9 @@ impl From<OpFormat5> for AluOpCode {
 
 pub(super) mod consts {
     pub(super) mod flags {
+        #[cfg(feature = "debugger")]
         pub const FLAG_H1: usize = 7;
+        #[cfg(feature = "debugger")]
         pub const FLAG_H2: usize = 6;
         pub const FLAG_R: usize = 8;
         pub const FLAG_S: usize = 7;

--- a/platform/rustboyadvance-sdl2/Cargo.toml
+++ b/platform/rustboyadvance-sdl2/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michel Heily <michelheily@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-rustboyadvance-core = { path = "../../core/", features = ["elf_support", "arm7tdmi_dispatch_table"] }
+rustboyadvance-core = { path = "../../core/", features = ["elf_support"] }
 sdl2 = { version = "0.33.0", features = ["image"] }
 ringbuf = "0.2.2"
 bytesize = "1.0.0"


### PR DESCRIPTION
Rust recently stabilized a subset of [const-generics](https://rust-lang.github.io/rfcs/2000-const-generics.html) and I thought it would be nice to use that for my arm interpreter,  as I already calculate the instruction lookup tables at build time.

The CPU seems 5-13%  faster, depending of what ROM i'm testing/

It still won't maintain 60FPS on my Xiaomi MiBox-S, *sigh* :cry: 