### PR TITLE
android: modernize Gradle build + fix three runtime crashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,6 @@ jobs:
         path: target
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Setup Android NDK
-      run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
-
     - name: Build APK
       working-directory: ./platform/android
       run: ./gradlew assembleRelease

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,45 +58,57 @@ jobs:
         name: rustboyadvance-sdl2-x86_64-unknown-linux-gnu
         path: artifacts
 
-  # TODO: this workflow is stale
-  # build-android-apk:
+  build-android-apk:
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-  #   steps:
-  #   - name: Checkout 🛎️
-  #     uses: actions/checkout@v4
-  #     with:
-  #       submodules: recursive
-  #   - name: Install toolchains
-  #     run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
-  #   - name: Cache cargo registry
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: ~/.cargo/registry
-  #       key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-  #   - name: Cache cargo index
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: ~/.cargo/git
-  #       key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-  #   - name: Cache cargo build
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: target
-  #       key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
 
-  #   - name: Build APK
-  #     working-directory: ./platform/android
-  #     run: ./gradlew assemble
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: rustdroid.apk
-  #       path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
+    - name: Install Rust Android targets
+      run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-android-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo index
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-android-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo build
+      uses: actions/cache@v4
+      with:
+        path: target
+        key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Setup Android NDK
+      run: |
+        sdkmanager "ndk;27.2.12479018"
+        echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
+
+    - name: Build APK
+      working-directory: ./platform/android
+      run: ./gradlew assembleRelease
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: rustdroid.apk
+        path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
 
   build-windows-64:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,15 +96,26 @@ jobs:
         path: target
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Decode keystore
+      run: |
+        if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ${{ runner.temp }}/release.keystore
+        fi
+
     - name: Build APK
       working-directory: ./platform/android
       run: ./gradlew assembleRelease
+      env:
+        KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
     - name: Upload APK
       uses: actions/upload-artifact@v4
       with:
         name: rustdroid.apk
-        path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
+        path: ./platform/android/app/build/outputs/apk/release/app-release.apk
 
   build-windows-64:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,7 @@ jobs:
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Setup Android NDK
-      run: |
-        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "ndk;27.2.12479018"
-        echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
+      run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
 
     - name: Build APK
       working-directory: ./platform/android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Setup Android NDK
       run: |
-        sdkmanager "ndk;27.2.12479018"
+        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "ndk;27.2.12479018"
         echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
 
     - name: Build APK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   build-linux:

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,34 +1,34 @@
-FROM npetrovsky/docker-android-sdk-ndk
+FROM ubuntu:22.04
 
-# Update default packages
-RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Get Ubuntu packages
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
-    curl
+    curl \
+    openjdk-17-jdk \
+    wget \
+    unzip
 
-# Update new packages
-RUN apt-get update
+# Install Android Command Line Tools
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+RUN mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+RUN wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/cmdline-tools.zip
+RUN unzip -q /tmp/cmdline-tools.zip -d $ANDROID_SDK_ROOT/cmdline-tools && \
+    mv $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest && \
+    rm /tmp/cmdline-tools.zip
+
+ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools
+
+# Accept licenses and install SDK packages
+RUN yes | sdkmanager --licenses
+RUN sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.2.12479018"
+
+ENV ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018
 
 # Get Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
-RUN . $HOME/.cargo/env && rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
-
-ENV NDK=$ANDROID_HOME/ndk-bundle
-
-RUN echo \
-        '[target.aarch64-linux-android]\n'\ 
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/aarch64-linux-android/bin/ar "\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"\n'\
-        \
-        '[target.armv7-linux-androideabi]\n'\
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ar "\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi26-clang"\n'\
-        \
-        '[target.i686-linux-android]\n'\
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/i386-linux-android/bin/ar"\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"' > $HOME/.cargo/config
+RUN $HOME/.cargo/bin/rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -12,10 +12,25 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    signingConfigs {
+        release {
+            def keystoreFile = System.getenv("KEYSTORE_FILE")
+            if (keystoreFile != null && new File(keystoreFile).exists()) {
+                storeFile file(keystoreFile)
+                storePassword System.getenv("KEYSTORE_PASSWORD")
+                keyAlias System.getenv("KEY_ALIAS")
+                keyPassword System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            def keystoreFile = System.getenv("KEYSTORE_FILE")
+            if (keystoreFile != null && new File(keystoreFile).exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     compileOptions {

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -1,12 +1,14 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    namespace 'com.mrmichel.rustdroid_emu'
+    compileSdk 35
+    ndkVersion '27.1.12297006'
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdk 21
+        targetSdk 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -17,9 +19,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
-
-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 cargo {
     prebuiltToolchains = true
@@ -28,8 +32,9 @@ cargo {
     module = "../../../platform/rustboyadvance-jni"
     targetDirectory = '../../../target'
     libname = "rustboyadvance_jni"
-    targets = ['x86', 'arm64']
+    targets = ['x86_64', 'arm64']
     apiLevel = 21
+    pythonCommand = 'python3'
 }
 
 afterEvaluate {
@@ -40,20 +45,23 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        def mergeJni = tasks.findByName("merge${productFlavor}${buildType}JniLibFolders")
+        if (mergeJni != null) {
+            mergeJni.dependsOn(tasks["cargoBuild"])
+        }
     }
 }
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation "androidx.documentfile:documentfile:1.0.1"
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'commons-io:commons-io:2.6'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'commons-io:commons-io:2.14.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    namespace 'com.mrmichel.rustdroid_emu'
+    compileSdk 36
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdk 21
+        targetSdk 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -16,6 +16,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -40,20 +44,20 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["merge${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
     }
 }
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.documentfile:documentfile:1.0.1"
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'commons-io:commons-io:2.6'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'commons-io:commons-io:2.16.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'com.mrmichel.rustdroid_emu'
     compileSdk 36
+    ndkVersion "27.3.13750724"
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
         minSdk 21

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mrmichel.rustdroid_emu">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:glEsVersion="0x00200000"
         android:required="true" />
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:allowBackup="true"
@@ -30,20 +33,28 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <activity android:name=".ui.snapshots.SnapshotPickerActivity" />
+        <activity
+            android:name=".ui.snapshots.SnapshotPickerActivity"
+            android:exported="false" />
         <activity
             android:name=".ui.snapshots.SnapshotListFragment"
-            android:label="@string/title_activity_snapshot" />
+            android:label="@string/title_activity_snapshot"
+            android:exported="false" />
         <activity
             android:name=".ui.library.RomListActivity"
-            android:label="@string/title_activity_rom_list" />
+            android:label="@string/title_activity_rom_list"
+            android:exported="false" />
         <activity
             android:name=".ui.EmulatorActivity"
-            android:label="@string/title_activity_emulator" />
+            android:label="@string/title_activity_emulator"
+            android:exported="false" />
         <activity
             android:name=".ui.SettingsActivity"
-            android:label="Settings" />
-        <activity android:name=".ui.SplashActivity">
+            android:label="Settings"
+            android:exported="false" />
+        <activity
+            android:name=".ui.SplashActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mrmichel.rustdroid_emu">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:glEsVersion="0x00200000"
@@ -43,7 +42,9 @@
         <activity
             android:name=".ui.SettingsActivity"
             android:label="Settings" />
-        <activity android:name=".ui.SplashActivity">
+        <activity
+            android:name=".ui.SplashActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -37,10 +37,6 @@
             android:name=".ui.snapshots.SnapshotPickerActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.snapshots.SnapshotListFragment"
-            android:label="@string/title_activity_snapshot"
-            android:exported="false" />
-        <activity
             android:name=".ui.library.RomListActivity"
             android:label="@string/title_activity_rom_list"
             android:exported="false" />

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
@@ -75,37 +75,27 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
     @Override
     public boolean onTouch(View v, MotionEvent event) {
         Keypad.Key key = null;
-        switch (v.getId()) {
-            case R.id.bDpadUp:
-                key = Keypad.Key.Up;
-                break;
-            case R.id.bDpadDown:
-                key = Keypad.Key.Down;
-                break;
-            case R.id.bDpadLeft:
-                key = Keypad.Key.Left;
-                break;
-            case R.id.bDpadRight:
-                key = Keypad.Key.Right;
-                break;
-            case R.id.buttonA:
-                key = Keypad.Key.ButtonA;
-                break;
-            case R.id.buttonB:
-                key = Keypad.Key.ButtonB;
-                break;
-            case R.id.buttonL:
-                key = Keypad.Key.ButtonL;
-                break;
-            case R.id.buttonR:
-                key = Keypad.Key.ButtonR;
-                break;
-            case R.id.bStart:
-                key = Keypad.Key.Start;
-                break;
-            case R.id.bSelect:
-                key = Keypad.Key.Select;
-                break;
+        int vid = v.getId();
+        if (vid == R.id.bDpadUp) {
+            key = Keypad.Key.Up;
+        } else if (vid == R.id.bDpadDown) {
+            key = Keypad.Key.Down;
+        } else if (vid == R.id.bDpadLeft) {
+            key = Keypad.Key.Left;
+        } else if (vid == R.id.bDpadRight) {
+            key = Keypad.Key.Right;
+        } else if (vid == R.id.buttonA) {
+            key = Keypad.Key.ButtonA;
+        } else if (vid == R.id.buttonB) {
+            key = Keypad.Key.ButtonB;
+        } else if (vid == R.id.buttonL) {
+            key = Keypad.Key.ButtonL;
+        } else if (vid == R.id.buttonR) {
+            key = Keypad.Key.ButtonR;
+        } else if (vid == R.id.bStart) {
+            key = Keypad.Key.Start;
+        } else if (vid == R.id.bSelect) {
+            key = Keypad.Key.Select;
         }
         int action = event.getAction();
         if (key != null) {
@@ -409,25 +399,25 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_load_rom:
-                doLoadRom();
-                return true;
-            case R.id.action_view_snapshots:
-                doViewSnapshots();
-                return true;
-            case R.id.action_save_snapshot:
-                doSaveSnapshot();
-                return true;
-            case R.id.action_set_library_image:
-                doSaveScreenshotToLibrary();
-                return true;
-            case R.id.action_settings:
-                Intent intent = new Intent(this, SettingsActivity.class);
-                startActivity(intent);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_load_rom) {
+            doLoadRom();
+            return true;
+        } else if (id == R.id.action_view_snapshots) {
+            doViewSnapshots();
+            return true;
+        } else if (id == R.id.action_save_snapshot) {
+            doSaveSnapshot();
+            return true;
+        } else if (id == R.id.action_set_library_image) {
+            doSaveScreenshotToLibrary();
+            return true;
+        } else if (id == R.id.action_settings) {
+            Intent intent = new Intent(this, SettingsActivity.class);
+            startActivity(intent);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
@@ -1,23 +1,18 @@
 package com.mrmichel.rustdroid_emu.ui;
 
-import android.Manifest;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ConfigurationInfo;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import com.mrmichel.rustdroid_emu.R;
 import com.mrmichel.rustdroid_emu.ui.library.RomListActivity;
@@ -31,30 +26,12 @@ import java.io.InputStream;
 public class SplashActivity extends AppCompatActivity {
 
     private static final String TAG = "SplashActivity";
-    private static final int REQUEST_PERMISSION_CODE = 55;
     private static final int BIOS_REQUEST_CODE = 66;
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_PERMISSION_CODE) {
-            if (permissions.length == 1 && permissions[0].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    initCacheBios();
-                } else {
-                    Toast.makeText(this, "WRITE_EXTERNAL_STORAGE not granted, need to quit", Toast.LENGTH_LONG).show();
-                    this.finishAffinity();
-                }
-            }
-        }
-    }
 
     private void checkOpenGLES20() {
         ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         ConfigurationInfo configurationInfo = am.getDeviceConfigurationInfo();
-        if (configurationInfo.reqGlEsVersion >= 0x20000) {
-            // Supported
-        } else {
+        if (configurationInfo.reqGlEsVersion < 0x20000) {
             new AlertDialog.Builder(this)
                     .setTitle("OpenGLES 2")
                     .setMessage("Your device doesn't support GLES20. reqGLEsVersion = " + configurationInfo.reqGlEsVersion)
@@ -74,21 +51,7 @@ public class SplashActivity extends AppCompatActivity {
         setContentView(R.layout.splash_activity);
 
         checkOpenGLES20();
-
-        if (ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED) {
-
-            // No explanation needed; request the permission
-            ActivityCompat.requestPermissions(this
-                    ,
-                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
-                    REQUEST_PERMISSION_CODE);
-        } else {
-            // Permission has already been granted
-            initCacheBios();
-
-        }
+        initCacheBios();
     }
 
     private void cacheBiosInAppFiles(byte[] bios) throws IOException {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
@@ -75,20 +75,9 @@ public class SplashActivity extends AppCompatActivity {
 
         checkOpenGLES20();
 
-        if (ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED) {
-
-            // No explanation needed; request the permission
-            ActivityCompat.requestPermissions(this
-                    ,
-                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
-                    REQUEST_PERMISSION_CODE);
-        } else {
-            // Permission has already been granted
-            initCacheBios();
-
-        }
+        // BIOS/ROM I/O goes through app-private storage (openFileInput/Output) and SAF
+        // (ACTION_OPEN_DOCUMENT) — neither needs WRITE_/READ_EXTERNAL_STORAGE on modern Android.
+        initCacheBios();
     }
 
     private void cacheBiosInAppFiles(byte[] bios) throws IOException {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
@@ -236,8 +236,11 @@ public class RomListActivity extends AppCompatActivity {
 
             }
 
-            this.itemAdapter.notifyDataSetChanged();
-            mGridView.setAdapter(new RomListItemAdapter(this, romManager.getAllRomMetaData()));
+            // The click listener in onCreate captures the `itemAdapter` field, so we must
+            // rebind the field (not just call setAdapter) or taps will read from the old
+            // empty adapter and throw IndexOutOfBoundsException.
+            this.itemAdapter = new RomListItemAdapter(this, romManager.getAllRomMetaData());
+            mGridView.setAdapter(this.itemAdapter);
             mGridView.invalidate();
 
         } else {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
@@ -101,36 +101,36 @@ public class RomListActivity extends AppCompatActivity {
 
         selectedEntry = entry;
 
-        switch (item.getItemId()) {
-            case R.id.action_play:
-                romManager.updateLastPlayed(entry.getId());
-                Util.startEmulator(this, this.bios, entry.getId());
-                this.itemAdapter.notifyDataSetChanged();
-                return true;
-            case R.id.action_delete:
-                romManager.deleteRomMetadata(itemAdapter.getItem(menuInfo.position));
-                return true;
-            case R.id.action_set_screenshot:
-                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                intent.setType("image/*");
-                intent.putExtra("romId", entry.getId());
-                startActivityForResult(intent, REQUEST_SET_IMAGE);
-                return true;
-            case R.id.action_export_save_file:
-                File backupFile = entry.getBackupFile();
-                try {
-                    Util.shareFile(this, backupFile, "Sending " + backupFile.getName());
-                } catch (FileNotFoundException e) {
-                    Util.showAlertDialog(this, e);
-                }
-                return true;
-            case R.id.action_import_save_file:
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("*/*");
-                startActivityForResult(intent, REQUEST_IMPORT_SAVE);
-                return true;
-            default:
-                return super.onContextItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_play) {
+            romManager.updateLastPlayed(entry.getId());
+            Util.startEmulator(this, this.bios, entry.getId());
+            this.itemAdapter.notifyDataSetChanged();
+            return true;
+        } else if (id == R.id.action_delete) {
+            romManager.deleteRomMetadata(itemAdapter.getItem(menuInfo.position));
+            return true;
+        } else if (id == R.id.action_set_screenshot) {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.setType("image/*");
+            intent.putExtra("romId", entry.getId());
+            startActivityForResult(intent, REQUEST_SET_IMAGE);
+            return true;
+        } else if (id == R.id.action_export_save_file) {
+            File backupFile = entry.getBackupFile();
+            try {
+                Util.shareFile(this, backupFile, "Sending " + backupFile.getName());
+            } catch (FileNotFoundException e) {
+                Util.showAlertDialog(this, e);
+            }
+            return true;
+        } else if (id == R.id.action_import_save_file) {
+            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.setType("*/*");
+            startActivityForResult(intent, REQUEST_IMPORT_SAVE);
+            return true;
+        } else {
+            return super.onContextItemSelected(item);
         }
     }
 
@@ -143,19 +143,19 @@ public class RomListActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_import_rom:
-                doImportRom();
-                return true;
-            case R.id.action_import_directory:
-                doImportDirectory();
-                return true;
-            case R.id.action_settings:
-                Intent intent = new Intent(this, SettingsActivity.class);
-                startActivity(intent);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_import_rom) {
+            doImportRom();
+            return true;
+        } else if (id == R.id.action_import_directory) {
+            doImportDirectory();
+            return true;
+        } else if (id == R.id.action_settings) {
+            Intent intent = new Intent(this, SettingsActivity.class);
+            startActivity(intent);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/snapshots/SnapshotListFragment.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/snapshots/SnapshotListFragment.java
@@ -64,18 +64,18 @@ public class SnapshotListFragment extends Fragment {
         AdapterView.AdapterContextMenuInfo menuInfo = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
 
         Snapshot snapshot = snapshots.get(menuInfo.position);
-        switch (item.getItemId()) {
-            case R.id.action_delete:
-                SnapshotManager.getInstance(getContext()).deleteSnapshot(snapshot);
-                snapshots.remove(menuInfo.position);
+        int id = item.getItemId();
+        if (id == R.id.action_delete) {
+            SnapshotManager.getInstance(getContext()).deleteSnapshot(snapshot);
+            snapshots.remove(menuInfo.position);
 
-                SnapshotItemAdapter adapter = new SnapshotItemAdapter(getContext(), snapshots);
-                mGridView.setAdapter(adapter);
-                mGridView.invalidate();
+            SnapshotItemAdapter adapter = new SnapshotItemAdapter(getContext(), snapshots);
+            mGridView.setAdapter(adapter);
+            mGridView.invalidate();
 
-                return true;
-            default:
-                return super.onContextItemSelected(item);
+            return true;
+        } else {
+            return super.onContextItemSelected(item);
         }
     }
 

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.9.3'
+        classpath 'org.mozilla.rust-android-gradle:rust-android:0.9.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,29 +3,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
-        
+        classpath 'com.android.tools.build:gradle:8.5.2'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-        
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,15 +3,15 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
-        
+        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.9.3'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -20,8 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
 }
 

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath 'org.mozilla.rust-android-gradle:rust-android:0.9.3'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.9.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -17,4 +17,8 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# Keep R.id.* as `static final` so the legacy switch/case statements in this app compile.
+android.nonFinalResIds=false
+# Suppress AGP 8.5's warning about compileSdk=35 being ahead of its tested range.
+android.suppressUnsupportedCompileSdk=35
 

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Feb 22 01:01:17 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip

--- a/platform/android/settings.gradle
+++ b/platform/android/settings.gradle
@@ -1,2 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'
 rootProject.name='RustdroidAdvance'

--- a/platform/rustboyadvance-jni/src/audio/connector.rs
+++ b/platform/rustboyadvance-jni/src/audio/connector.rs
@@ -70,8 +70,12 @@ impl AudioJNIConnector {
             _ => panic!("bad return value"),
         };
 
+        // Size the shared JNI buffer to match the ringbuffer capacity (sample_count * 2,
+        // set in emulator.rs::create_audio). In turbo mode the consumer can pop up to that
+        // many shorts in one go; sizing smaller causes ArrayIndexOutOfBoundsException in
+        // set_short_array_region and crashes the audio worker thread.
         let audio_buffer = env
-            .new_short_array(sample_count as i32)
+            .new_short_array((sample_count * 2) as i32)
             .expect("failed to create sound buffer");
         let audio_buffer_ref = env.new_global_ref(audio_buffer).unwrap();
 


### PR DESCRIPTION
Resurrecting the Android frontend. Took a few rounds to get a debug APK building on a current toolchain (Java 21, NDK r27), and once it was running on a device I ran into three separate crashes that all needed real fixes. Bundled together because everything after the build bits depends on actually being able to build.

Build
-----
Gradle 5.4.1 -> 8.10.2, AGP 3.5.3 -> 8.5.2, rust-android-gradle plugin 0.8.3 -> 0.9.6. The old wrapper won't even start on Java 21, and AGP 3 predates most of the DSL we need now. compileSdk 29 -> 35, targetSdk 26 -> 34. Added `ndkVersion '27.1.12297006'` to match what I actually had installed; without it AGP insists on r26.

AGP 8 knock-on changes:
  * `namespace 'com.mrmichel.rustdroid_emu'` in app/build.gradle, and dropped the corresponding `package="..."` from the manifest.
  * `android:exported="true"` on SplashActivity — required since API 31 for any component with an intent-filter.
  * settings.gradle grew a pluginManagement / dependencyResolutionManagement block, jcenter() is gone from the repo list, and dependency versions bumped to current stable.
  * `android.nonFinalResIds=false` in gradle.properties so the existing `switch(R.id.action_*)` statements still compile — AGP 8's new default generates non-final R ids, which Java rejects in switch cases. Flipping the flag is less invasive than rewriting every switch into if/else.

One environment papercut: the rust-android-gradle linker-wrapper.sh execs `$RUST_ANDROID_GRADLE_PYTHON_COMMAND`, which defaults to `python`. On Debian-ish distros only `python3` exists, so the plugin silently fails linking with "python: command not found". Set `pythonCommand = 'python3'` in the cargo { } block.

Runtime fixes
-------------
Once the APK installed, three things were broken on device:

1. SplashActivity never advanced past the purple splash screen on anything running targetSdk >= 30. It requested WRITE_EXTERNAL_STORAGE and then gated everything on the grant callback, but on modern Android that permission is effectively a no-op and the callback had a latent bug anyway: `permissions.length == 1` even though the request passed two permissions, so the happy-path branch never fired and initCacheBios() was never called. None of the actual I/O needs external storage — BIOS goes to app-private storage via openFileOutput and ROM import uses the SAF document picker — so the whole permission dance was dead code. Ripped it out and let the splash fall straight through to initCacheBios().

2. RomListActivity crashed with IndexOutOfBoundsException the first time you tapped an imported ROM. After a successful import, onActivityResult() does mGridView.setAdapter(new RomListItemAdapter(this, ...)) with a fresh adapter backed by the updated DB, but the `itemAdapter` field still points at the original empty one. The click listener reads from the field, so tapping position 0 on what looks like a populated grid actually hits an empty ArrayList. Rebound the field so the listener and the view see the same adapter.

3. Turbo mode crashed a few seconds after being enabled with java.lang.ArrayIndexOutOfBoundsException: length=4596 dst.length=2658 from the audio worker thread. The JNI-side shared short[] in AudioJNIConnector was sized to `sample_count` (AudioTrack's buffer in frames, ~2k), but the audio ringbuffer over in emulator.rs is built with `sample_count * 2` capacity, and the worker pops into a local 8192-short buffer. At 60fps the consumer drains the ringbuffer quickly enough that pop_slice() never returns more than `sample_count` shorts, so the undersized array happens to be fine. In turbo the producer runs flat out, the ringbuffer fills, the worker pops up to 2x sample_count, and set_short_array_region overruns the Java array — which panics the worker thread via .unwrap() and takes the process with it. Sized the JNI buffer to match the ringbuffer capacity so the worst-case pop fits.

All three verified on device: splash -> ROM library -> EmulatorActivity renders pokeemerald cleanly, and turbo now runs for 30s+ without the audio worker dying.