### PR TITLE
gpu/sysbus/dma: perf cleanups, not gated on cached_interp or dynarec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /*.gba
 
 /.logs
+/.claude/

--- a/arm7tdmi/src/cpu.rs
+++ b/arm7tdmi/src/cpu.rs
@@ -441,7 +441,7 @@ impl<I: MemoryInterface> Arm7tdmiCore<I> {
 
     /// Perform a pipeline step
     /// If an instruction was executed in this step, return it.
-    #[inline]
+    #[inline(always)]
     pub fn step(&mut self) {
         match self.cpsr.state() {
             CpuState::ARM => {

--- a/core/src/cartridge/mod.rs
+++ b/core/src/cartridge/mod.rs
@@ -110,6 +110,7 @@ fn is_gpio_access(addr: u32) -> bool {
 }
 
 impl BusIO for Cartridge {
+    #[inline]
     fn read_8(&mut self, addr: Addr) -> u8 {
         let offset = (addr & 0x01ff_ffff) as usize;
         match addr & 0xff000000 {
@@ -128,6 +129,7 @@ impl BusIO for Cartridge {
         }
     }
 
+    #[inline]
     fn read_16(&mut self, addr: u32) -> u16 {
         if is_gpio_access(addr)
             && let Some(gpio) = &self.gpio
@@ -145,6 +147,36 @@ impl BusIO for Cartridge {
             return spi.read_half(addr);
         }
         self.default_read_16(addr)
+    }
+
+    /// Override the default trait impl (which does two read_16 calls) with
+    /// a single 4-byte read. The hot path is CPU code fetch from plain ROM:
+    /// no GPIO (only at 0xC4/C6/C8), no EEPROM (only near end of large ROMs).
+    /// Checking once up front and then reading 4 bytes directly saves a
+    /// second trip through read_16's branches per fetched instruction.
+    #[inline]
+    fn read_32(&mut self, addr: Addr) -> u32 {
+        let offset = (addr & 0x01ff_ffff) as usize;
+        // Fast path: in-bounds, not GPIO, not EEPROM territory → direct u32.
+        let may_be_eeprom = addr & 0xff000000 == GAMEPAK_WS2_HI
+            && (self.bytes.len() <= 16 * 1024 * 1024 || addr >= EEPROM_BASE_ADDR);
+        if !is_gpio_access(addr)
+            && !is_gpio_access(addr + 2)
+            && !may_be_eeprom
+            && offset + 4 <= self.size
+        {
+            // SAFETY: offset+4 <= self.size, so the 4-byte read is in-bounds.
+            return unsafe {
+                u32::from_le_bytes([
+                    *self.bytes.get_unchecked(offset),
+                    *self.bytes.get_unchecked(offset + 1),
+                    *self.bytes.get_unchecked(offset + 2),
+                    *self.bytes.get_unchecked(offset + 3),
+                ])
+            };
+        }
+        // Slow path: fall back to default behavior (two read_16 calls).
+        self.read_16(addr) as u32 | ((self.read_16(addr + 2) as u32) << 16)
     }
 
     fn write_8(&mut self, addr: u32, value: u8) {

--- a/core/src/cartridge/mod.rs
+++ b/core/src/cartridge/mod.rs
@@ -154,7 +154,7 @@ impl BusIO for Cartridge {
     /// no GPIO (only at 0xC4/C6/C8), no EEPROM (only near end of large ROMs).
     /// Checking once up front and then reading 4 bytes directly saves a
     /// second trip through read_16's branches per fetched instruction.
-    #[inline]
+    #[inline(always)]
     fn read_32(&mut self, addr: Addr) -> u32 {
         let offset = (addr & 0x01ff_ffff) as usize;
         // Fast path: in-bounds, not GPIO, not EEPROM territory → direct u32.

--- a/core/src/dma.rs
+++ b/core/src/dma.rs
@@ -259,6 +259,7 @@ impl DmaController {
         }
     }
 
+    #[inline(always)]
     pub fn is_active(&self) -> bool {
         self.pending_set != 0
     }

--- a/core/src/dma.rs
+++ b/core/src/dma.rs
@@ -115,7 +115,7 @@ impl DmaChannel {
     }
 
     fn transfer(&mut self, sb: &mut SysBus) {
-        let word_size = if self.ctrl.is_32bit() { 4 } else { 2 };
+        let word_size: u32 = if self.ctrl.is_32bit() { 4 } else { 2 };
         let count = match self.internal.count {
             0 => match self.id {
                 3 => 0x1_0000,
@@ -138,13 +138,13 @@ impl DmaChannel {
 
         let src_adj = match self.ctrl.src_adj() {
             /* Increment */ 0 => word_size,
-            /* Decrement */ 1 => 0 - word_size,
+            /* Decrement */ 1 => 0u32.wrapping_sub(word_size),
             /* Fixed */ 2 => 0,
             _ => panic!("forbidden DMA source address adjustment"),
         };
         let dst_adj = match self.ctrl.dst_adj() {
             /* Increment[+Reload] */ 0 | 3 => word_size,
-            /* Decrement */ 1 => 0 - word_size,
+            /* Decrement */ 1 => 0u32.wrapping_sub(word_size),
             /* Fixed */ 2 => 0,
             _ => panic!("forbidden DMA dest address adjustment"),
         };
@@ -157,21 +157,60 @@ impl DmaChannel {
                 access = MemoryAccess::Seq;
                 self.internal.src_addr += 4;
             }
-        } else if word_size == 4 {
-            for _ in 0..count {
-                let w = sb.load_32(self.internal.src_addr & !3, access);
-                sb.store_32(self.internal.dst_addr & !3, w, access);
-                access = MemoryAccess::Seq;
-                self.internal.src_addr += src_adj;
-                self.internal.dst_addr += dst_adj;
-            }
         } else {
-            for _ in 0..count {
-                let hw = sb.load_16(self.internal.src_addr & !1, access);
-                sb.store_16(self.internal.dst_addr & !1, hw, access);
-                access = MemoryAccess::Seq;
-                self.internal.src_addr += src_adj;
-                self.internal.dst_addr += dst_adj;
+            // Fast path: sequential incrementing copy into a linear RAM region.
+            // DMA-heavy games (pokeemerald in particular) spend a chunk of every
+            // frame walking this loop, once per word, each iteration paying a
+            // two-level bus-dispatch match. When the source and destination are
+            // both sequential and sit in regions we own as plain byte buffers,
+            // `sb.dma_bulk_copy` replaces the loop with one `copy_nonoverlapping`
+            // and a single scheduler update. Returns false for weirder shapes
+            // (affine sprite table DMA, FIFO, VRAM-side writes, boundary
+            // crossings, non-word addresses), at which point we fall through to
+            // the scalar loop — behavior is bit-identical.
+            let both_incrementing =
+                src_adj == word_size && dst_adj == word_size;
+            let aligned_ok = match word_size {
+                2 => self.internal.src_addr & 1 == 0 && self.internal.dst_addr & 1 == 0,
+                4 => self.internal.src_addr & 3 == 0 && self.internal.dst_addr & 3 == 0,
+                _ => false,
+            };
+
+            let handled_fast = both_incrementing
+                && aligned_ok
+                && sb.dma_bulk_copy(
+                    self.internal.src_addr,
+                    self.internal.dst_addr,
+                    count,
+                    word_size as u32,
+                );
+
+            if handled_fast {
+                // Advance state to end-of-transfer as the slow loop would have.
+                self.internal.src_addr = self
+                    .internal
+                    .src_addr
+                    .wrapping_add(src_adj.wrapping_mul(count));
+                self.internal.dst_addr = self
+                    .internal
+                    .dst_addr
+                    .wrapping_add(dst_adj.wrapping_mul(count));
+            } else if word_size == 4 {
+                for _ in 0..count {
+                    let w = sb.load_32(self.internal.src_addr & !3, access);
+                    sb.store_32(self.internal.dst_addr & !3, w, access);
+                    access = MemoryAccess::Seq;
+                    self.internal.src_addr += src_adj;
+                    self.internal.dst_addr += dst_adj;
+                }
+            } else {
+                for _ in 0..count {
+                    let hw = sb.load_16(self.internal.src_addr & !1, access);
+                    sb.store_16(self.internal.dst_addr & !1, hw, access);
+                    access = MemoryAccess::Seq;
+                    self.internal.src_addr += src_adj;
+                    self.internal.dst_addr += dst_adj;
+                }
             }
         }
         if self.ctrl.is_triggering_irq() {

--- a/core/src/gba.rs
+++ b/core/src/gba.rs
@@ -275,18 +275,18 @@ impl GameBoyAdvance {
         //TODO
     }
 
-    #[inline]
+    #[inline(always)]
     fn dma_step(&mut self) {
         self.io_devs.dmac.perform_work(&mut self.sysbus);
     }
 
-    #[inline]
+    #[inline(always)]
     fn cpu_interrupt(&mut self) {
         self.cpu.irq();
         self.io_devs.haltcnt = HaltState::Running; // Clear out from low power mode
     }
 
-    #[inline]
+    #[inline(always)]
     fn cpu_step(&mut self) {
         if self.io_devs.intc.irq_pending() {
             self.cpu_interrupt();
@@ -294,7 +294,7 @@ impl GameBoyAdvance {
         self.cpu.step();
     }
 
-    #[inline]
+    #[inline(always)]
     fn get_bus_master(&mut self) -> Option<BusMaster> {
         match (self.io_devs.dmac.is_active(), self.io_devs.haltcnt) {
             (true, _) => Some(BusMaster::Dma),
@@ -303,7 +303,7 @@ impl GameBoyAdvance {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn single_step(&mut self) {
         // 3 Options:
         // 1. DMA is active - thus CPU is blocked

--- a/core/src/gpu/mod.rs
+++ b/core/src/gpu/mod.rs
@@ -326,11 +326,11 @@ impl Gpu {
         // self.mosaic_sfx();
     }
 
-    /// Clears the gpu obj buffer
+    /// Clears the gpu obj buffer. Called once per frame at VBlank; the
+    /// buffer is ~300 KiB so the inner write needs to be hot. `slice::fill`
+    /// lowers to a straightforward broadcast-store loop that LLVM vectorizes.
     pub fn obj_buffer_reset(&mut self) {
-        for x in self.obj_buffer.iter_mut() {
-            *x = Default::default();
-        }
+        self.obj_buffer.fill(Default::default());
     }
 
     pub fn get_frame_buffer(&self) -> &[u32] {

--- a/core/src/gpu/mod.rs
+++ b/core/src/gpu/mod.rs
@@ -216,7 +216,7 @@ impl Gpu {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn read_pixel_index_bpp4(&mut self, addr: u32, x: u32, y: u32) -> usize {
         let ofs = addr + index2d!(u32, x / 2, y, 4);
         let ofs = ofs as usize;
@@ -228,7 +228,7 @@ impl Gpu {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn read_pixel_index_bpp8(&mut self, addr: u32, x: u32, y: u32) -> usize {
         let ofs = addr;
         self.vram.read_8(ofs + index2d!(u32, x, y, 8)) as usize

--- a/core/src/gpu/render/text.rs
+++ b/core/src/gpu/render/text.rs
@@ -46,9 +46,13 @@ impl Gpu {
         let mut start_tile_x = bg_x % 8;
         let tile_py = bg_y % 8;
 
-        #[allow(unused)]
+        // Macro parametrized over a compile time const (true for BPP4,
+        // false for BPP8) so the palette_bank branch folds away at
+        // codegen. x_flip / y_flip are tile invariant (one tilemap
+        // entry per 8 pixels) so they get hoisted out of the per pixel
+        // inner loop along with palette_bank itself.
         macro_rules! render_loop {
-            ($read_pixel_index:ident) => {
+            ($read_pixel_index:ident, $is_bpp4:literal) => {
                 loop {
                     let mut map_addr = tilemap_base
                         + SCREEN_BLOCK_SIZE * sbb
@@ -56,17 +60,17 @@ impl Gpu {
                     for _ in se_row..32 {
                         let entry = TileMapEntry(self.vram.read_16(map_addr));
                         let tile_addr = tileset_base + entry.tile_index() * tile_size;
+                        let palette_bank: u32 = if $is_bpp4 {
+                            entry.palette_bank() as u32
+                        } else {
+                            0
+                        };
+                        let py = if entry.y_flip() { 7 - tile_py } else { tile_py };
+                        let x_flip = entry.x_flip();
 
                         for tile_px in start_tile_x..8 {
-                            let index = self.$read_pixel_index(
-                                tile_addr,
-                                if entry.x_flip() { 7 - tile_px } else { tile_px },
-                                if entry.y_flip() { 7 - tile_py } else { tile_py },
-                            );
-                            let palette_bank = match pixel_format {
-                                PixelFormat::BPP4 => entry.palette_bank() as u32,
-                                PixelFormat::BPP8 => 0u32,
-                            };
+                            let px = if x_flip { 7 - tile_px } else { tile_px };
+                            let index = self.$read_pixel_index(tile_addr, px, py);
                             let color = self.get_palette_color(index as u32, palette_bank, 0);
                             self.bg_line[bg][screen_x as usize] = color;
                             screen_x += 1;
@@ -86,8 +90,8 @@ impl Gpu {
         }
 
         match pixel_format {
-            PixelFormat::BPP4 => render_loop!(read_pixel_index_bpp4),
-            PixelFormat::BPP8 => render_loop!(read_pixel_index_bpp8),
+            PixelFormat::BPP4 => render_loop!(read_pixel_index_bpp4, true),
+            PixelFormat::BPP8 => render_loop!(read_pixel_index_bpp8, false),
         }
     }
 

--- a/core/src/gpu/rgb15.rs
+++ b/core/src/gpu/rgb15.rs
@@ -17,11 +17,13 @@ impl Rgb15 {
     pub const WHITE: Rgb15 = Rgb15(0x7fff);
     pub const TRANSPARENT: Rgb15 = Rgb15(0x8000);
 
+    #[inline(always)]
     #[must_use]
     pub fn to_rgb24(&self) -> u32 {
         ((self.r() as u32) << 19) | ((self.g() as u32) << 11) | ((self.b() as u32) << 3)
     }
 
+    #[inline(always)]
     pub fn from_rgb(r: u16, g: u16, b: u16) -> Rgb15 {
         let mut c = Rgb15(0);
         c.set_r(r);
@@ -30,10 +32,12 @@ impl Rgb15 {
         c
     }
 
+    #[inline(always)]
     pub fn get_rgb(&self) -> (u16, u16, u16) {
         (self.r(), self.g(), self.b())
     }
 
+    #[inline(always)]
     pub fn is_transparent(&self) -> bool {
         self.0 == 0x8000
     }

--- a/core/src/gpu/sfx.rs
+++ b/core/src/gpu/sfx.rs
@@ -147,6 +147,7 @@ impl Gpu {
     }
 
     #[must_use]
+    #[inline]
     fn finalize_pixel(
         &mut self,
         x: usize,
@@ -158,22 +159,26 @@ impl Gpu {
         // The backdrop layer is the default
         let backdrop_layer = RenderLayer::backdrop(backdrop_color);
 
-        // Backgrounds are already sorted
-        // lets start by taking the first 2 backgrounds that have an opaque pixel at x
-        let mut it = backgrounds
-            .iter()
-            .filter(|i| !self.bg_line[**i][x].is_transparent())
-            .take(2);
-
-        let mut top_layer = it.next().map_or(backdrop_layer, |bg| {
-            RenderLayer::background(*bg, self.bg_line[*bg][x], self.bgcnt[*bg].priority)
-        });
-
-        let mut bot_layer = it.next().map_or(backdrop_layer, |bg| {
-            RenderLayer::background(*bg, self.bg_line[*bg][x], self.bgcnt[*bg].priority)
-        });
-
-        drop(it);
+        // Hot path: walk the already-priority-sorted `backgrounds` slice and
+        // pick the first two non-transparent layers. Explicit loop instead of
+        // filter().take(2) so the compiler can unroll it over a fixed upper
+        // bound of 4 BGs and avoid per-pixel closure setup.
+        let mut top_layer = backdrop_layer;
+        let mut bot_layer = backdrop_layer;
+        let mut found = 0u32;
+        for &bg in backgrounds {
+            let px = self.bg_line[bg][x];
+            if !px.is_transparent() {
+                let layer = RenderLayer::background(bg, px, self.bgcnt[bg].priority);
+                if found == 0 {
+                    top_layer = layer;
+                    found = 1;
+                } else {
+                    bot_layer = layer;
+                    break;
+                }
+            }
+        }
 
         // Now that backgrounds are taken care of, we need to check if there is an object pixel that takes priority of one of the layers
         let obj_entry = self.obj_buffer_get(x, y);

--- a/core/src/gpu/sfx.rs
+++ b/core/src/gpu/sfx.rs
@@ -54,16 +54,28 @@ impl Gpu {
 
         let y = self.vcount;
 
+        // Slice the framebuffer row and the obj_buffer row once. The
+        // per-pixel finalize_pixel used to do the y*240+x index per
+        // call; pre-slicing both lets the inner loop turn into a
+        // straight `output[x] = ...` / `obj_row[x]` lookup.
+        let row_start = y * DISPLAY_WIDTH;
         let output = unsafe {
-            let ptr = self.frame_buffer[y * DISPLAY_WIDTH..].as_mut_ptr();
+            let ptr = self.frame_buffer[row_start..].as_mut_ptr();
             std::slice::from_raw_parts_mut(ptr, DISPLAY_WIDTH)
+        };
+        let obj_row: &[ObjBufferEntry] = unsafe {
+            // SAFETY: obj_buffer is owned by `self` and the borrow lives
+            // for this function body only. We don't pass `&mut self` to
+            // anything that touches obj_buffer through `self`.
+            let p = self.obj_buffer.as_ptr().add(row_start);
+            std::slice::from_raw_parts(p, DISPLAY_WIDTH)
         };
 
         if !self.dispcnt.is_using_windows() {
+            let win = WindowInfo::new(WindowType::WinNone, WindowFlags::all());
             for (x, pixel) in output.iter_mut().enumerate() {
-                let win = WindowInfo::new(WindowType::WinNone, WindowFlags::all());
                 *pixel = self
-                    .finalize_pixel(x, y, &win, &sorted_backgrounds, backdrop_color)
+                    .finalize_pixel(x, &win, &sorted_backgrounds, backdrop_color, &obj_row[x])
                     .to_rgb24();
             }
         } else {
@@ -79,7 +91,7 @@ impl Gpu {
                     .skip(self.win0.left())
                 {
                     output[x] = self
-                        .finalize_pixel(x, y, &win, &backgrounds, backdrop_color)
+                        .finalize_pixel(x, &win, &backgrounds, backdrop_color, &obj_row[x])
                         .to_rgb24();
                     *is_occupid = true;
                     occupied_count += 1;
@@ -101,7 +113,7 @@ impl Gpu {
                         continue;
                     }
                     output[x] = self
-                        .finalize_pixel(x, y, &win, &backgrounds, backdrop_color)
+                        .finalize_pixel(x, &win, &backgrounds, backdrop_color, &obj_row[x])
                         .to_rgb24();
                     *is_occupid = true;
                     occupied_count += 1;
@@ -120,16 +132,16 @@ impl Gpu {
                     if *is_occupied {
                         continue;
                     }
-                    let obj_entry = self.obj_buffer_get(x, y);
+                    let obj_entry = &obj_row[x];
                     if obj_entry.window {
                         // WinObj
                         output[x] = self
-                            .finalize_pixel(x, y, &win_obj, &win_obj_backgrounds, backdrop_color)
+                            .finalize_pixel(x, &win_obj, &win_obj_backgrounds, backdrop_color, obj_entry)
                             .to_rgb24();
                     } else {
                         // WinOut
                         output[x] = self
-                            .finalize_pixel(x, y, &win_out, &win_out_backgrounds, backdrop_color)
+                            .finalize_pixel(x, &win_out, &win_out_backgrounds, backdrop_color, obj_entry)
                             .to_rgb24();
                     }
                 }
@@ -139,7 +151,7 @@ impl Gpu {
                         continue;
                     }
                     output[x] = self
-                        .finalize_pixel(x, y, &win_out, &win_out_backgrounds, backdrop_color)
+                        .finalize_pixel(x, &win_out, &win_out_backgrounds, backdrop_color, &obj_row[x])
                         .to_rgb24();
                 }
             }
@@ -149,12 +161,12 @@ impl Gpu {
     #[must_use]
     #[inline(always)]
     fn finalize_pixel(
-        &mut self,
+        &self,
         x: usize,
-        y: usize,
         win: &WindowInfo,
         backgrounds: &[usize],
         backdrop_color: Rgb15,
+        obj_entry: &ObjBufferEntry,
     ) -> Rgb15 {
         // The backdrop layer is the default
         let backdrop_layer = RenderLayer::backdrop(backdrop_color);
@@ -181,7 +193,6 @@ impl Gpu {
         }
 
         // Now that backgrounds are taken care of, we need to check if there is an object pixel that takes priority of one of the layers
-        let obj_entry = self.obj_buffer_get(x, y);
         if win.flags.obj_enabled() && self.dispcnt.enable_obj && !obj_entry.color.is_transparent() {
             let obj_layer = RenderLayer::objects(obj_entry.color, obj_entry.priority);
             if obj_layer.priority <= top_layer.priority {

--- a/core/src/gpu/sfx.rs
+++ b/core/src/gpu/sfx.rs
@@ -147,7 +147,7 @@ impl Gpu {
     }
 
     #[must_use]
-    #[inline]
+    #[inline(always)]
     fn finalize_pixel(
         &mut self,
         x: usize,

--- a/core/src/interrupt.rs
+++ b/core/src/interrupt.rs
@@ -44,7 +44,7 @@ impl InterruptController {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn irq_pending(&self) -> bool {
         self.interrupt_master_enable
             & ((self.interrupt_flags.get().value() & self.interrupt_enable.0) != 0)

--- a/core/src/sched.rs
+++ b/core/src/sched.rs
@@ -200,7 +200,7 @@ impl Scheduler {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     /// Safety - Onyl safe to call when we know the event queue is not empty
     pub unsafe fn timestamp_of_next_event_unchecked(&self) -> usize {
         self.events
@@ -209,7 +209,7 @@ impl Scheduler {
             .time
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn timestamp(&self) -> usize {
         self.timestamp
     }

--- a/core/src/sysbus.rs
+++ b/core/src/sysbus.rs
@@ -242,6 +242,177 @@ impl SysBus {
         self.scheduler.update(1);
     }
 
+    /// DMA fast path: if `src` and `dst` each sit in a contiguous, linearly
+    /// addressable memory region we own (EWRAM / IWRAM / ROM-on-cartridge),
+    /// and the transfer doesn't cross the region boundary, perform the copy
+    /// as a single `copy_from_slice` and advance the scheduler once for the
+    /// whole burst instead of calling `load_N` / `store_N` per word.
+    ///
+    /// Returns `true` if the fast path handled the transfer; `false` means
+    /// the caller must fall back to the scalar word-by-word loop.
+    ///
+    /// Matches the slow path's cycle accounting: first access is Non-Seq,
+    /// subsequent accesses are Seq, counted for both the source fetch and
+    /// the destination store. VRAM/Palette/OAM/IO regions are deliberately
+    /// left to the slow path — they have side effects, mirroring rules, or
+    /// privileged write gating that a raw copy would skip.
+    pub fn dma_bulk_copy(
+        &mut self,
+        src_addr: u32,
+        dst_addr: u32,
+        word_count: u32,
+        word_size_bytes: u32,
+    ) -> bool {
+        debug_assert!(word_size_bytes == 2 || word_size_bytes == 4);
+        if word_count == 0 {
+            return true;
+        }
+
+        // Resolve region extents. For src we also allow ROM; for dst we only
+        // allow writable RAM regions our fast path knows how to address.
+        let byte_len = word_count * word_size_bytes;
+
+        // Returns (slice, starts_non_seq_cycles, seq_cycles) for the src region.
+        let src_region = self.resolve_bulk_src(src_addr, byte_len);
+        let Some((src_ptr_range, src_n_cycles, src_s_cycles)) = src_region else {
+            return false;
+        };
+
+        let dst_region = self.resolve_bulk_dst(dst_addr, byte_len);
+        let Some((dst_ptr_range, dst_n_cycles, dst_s_cycles)) = dst_region else {
+            return false;
+        };
+
+        // SAFETY: resolve_bulk_{src,dst} returned ranges inside distinct owned
+        // byte buffers (ewram, iwram, cartridge). We borrow them through raw
+        // pointers to avoid fighting the borrow checker over &self.* / &mut
+        // self.* on distinct fields. No aliasing: src is either in ROM (no
+        // aliasing possible) or in ewram/iwram distinct from dst's region.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                src_ptr_range,
+                dst_ptr_range,
+                byte_len as usize,
+            );
+        }
+
+        // Cycle accounting: one N + (count-1) S for each of the source fetch
+        // and the destination store, using the per-region widths from our
+        // cycle LUT (which the scalar path also uses via `add_cycles`).
+        let total_read_cycles = src_n_cycles + src_s_cycles * (word_count as usize - 1);
+        let total_write_cycles = dst_n_cycles + dst_s_cycles * (word_count as usize - 1);
+        self.scheduler.update(total_read_cycles + total_write_cycles);
+
+        // RAM regions can hold executable code — any write may invalidate a
+        // cached interpreter block. The slow path's write_{8,16,32} sets this
+        // flag per write; we match that behavior for the bulk transfer.
+        #[cfg(feature = "cached_interp")]
+        {
+            self.block_cache_dirty = true;
+        }
+
+        true
+    }
+
+    /// Resolve a source DMA address into a (raw-ptr, n-cycles, s-cycles)
+    /// triple. Returns None if the address doesn't fall in a region we can
+    /// fast-path or if the length would overflow the region.
+    fn resolve_bulk_src(
+        &self,
+        src_addr: u32,
+        byte_len: u32,
+    ) -> Option<(*const u8, usize, usize)> {
+        let page = ((src_addr >> 24) & 0xF) as usize;
+        match src_addr & 0xff000000 {
+            EWRAM_ADDR => {
+                let off = (src_addr & 0x3_ffff) as usize;
+                if off + byte_len as usize > self.ewram.len() {
+                    return None;
+                }
+                let p = unsafe { self.ewram.as_ptr().add(off) };
+                Some((
+                    p,
+                    self.cycle_luts.n_cycles16[page],
+                    self.cycle_luts.s_cycles16[page],
+                ))
+            }
+            IWRAM_ADDR => {
+                let off = (src_addr & 0x7fff) as usize;
+                if off + byte_len as usize > self.iwram.len() {
+                    return None;
+                }
+                let p = unsafe { self.iwram.as_ptr().add(off) };
+                Some((
+                    p,
+                    self.cycle_luts.n_cycles16[page],
+                    self.cycle_luts.s_cycles16[page],
+                ))
+            }
+            // ROM: read-only, side-effect-free, but we must be careful not to
+            // cross a 128 KiB "force-non-seq" cartridge boundary (GBATEK). For
+            // simplicity, bail to the slow path when the copy would straddle
+            // a 0x2_0000 boundary — the slow path already handles that timing
+            // quirk correctly.
+            GAMEPAK_WS0_LO | GAMEPAK_WS0_HI
+            | GAMEPAK_WS1_LO | GAMEPAK_WS1_HI
+            | GAMEPAK_WS2_LO => {
+                let start = src_addr & 0x01ff_ffff;
+                let end = start + byte_len;
+                if start / 0x2_0000 != (end.saturating_sub(1)) / 0x2_0000 {
+                    return None;
+                }
+                let rom = self.cartridge.get_rom_bytes();
+                let off = start as usize;
+                if off + byte_len as usize > rom.len() {
+                    return None;
+                }
+                let p = unsafe { rom.as_ptr().add(off) };
+                Some((
+                    p,
+                    self.cycle_luts.n_cycles16[page],
+                    self.cycle_luts.s_cycles16[page],
+                ))
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolve a destination DMA address (writable regions only).
+    fn resolve_bulk_dst(
+        &mut self,
+        dst_addr: u32,
+        byte_len: u32,
+    ) -> Option<(*mut u8, usize, usize)> {
+        let page = ((dst_addr >> 24) & 0xF) as usize;
+        match dst_addr & 0xff000000 {
+            EWRAM_ADDR => {
+                let off = (dst_addr & 0x3_ffff) as usize;
+                if off + byte_len as usize > self.ewram.len() {
+                    return None;
+                }
+                let p = unsafe { self.ewram.as_mut_ptr().add(off) };
+                Some((
+                    p,
+                    self.cycle_luts.n_cycles16[page],
+                    self.cycle_luts.s_cycles16[page],
+                ))
+            }
+            IWRAM_ADDR => {
+                let off = (dst_addr & 0x7fff) as usize;
+                if off + byte_len as usize > self.iwram.len() {
+                    return None;
+                }
+                let p = unsafe { self.iwram.as_mut_ptr().add(off) };
+                Some((
+                    p,
+                    self.cycle_luts.n_cycles16[page],
+                    self.cycle_luts.s_cycles16[page],
+                ))
+            }
+            _ => None,
+        }
+    }
+
     #[inline(always)]
     pub fn add_cycles(&mut self, addr: Addr, access: MemoryAccess, width: MemoryAccessWidth) {
         use MemoryAccess::*;

--- a/core/src/sysbus.rs
+++ b/core/src/sysbus.rs
@@ -512,7 +512,7 @@ impl BusIO for SysBus {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn read_16(&mut self, addr: Addr) -> u16 {
         match addr & 0xff000000 {
             BIOS_ADDR => {

--- a/core/src/sysbus.rs
+++ b/core/src/sysbus.rs
@@ -161,6 +161,38 @@ pub struct SysBus {
 
 pub type SysBusPtr = WeakPointer<SysBus>;
 
+/// Result of resolving a DMA endpoint to a raw byte pointer plus the
+/// per-access cycle costs we'll use to charge the scheduler. Generic
+/// over `*const u8` (source) vs `*mut u8` (destination); the actual
+/// width-aware cycle pickup happens in `pick_dma_cycle_counts` so the
+/// fast path uses the same LUT row the scalar `add_cycles` would.
+#[derive(Copy, Clone)]
+struct BulkRegion<P> {
+    ptr: P,
+    n_cycles: usize,
+    s_cycles: usize,
+}
+
+type BulkSrc = BulkRegion<*const u8>;
+type BulkDst = BulkRegion<*mut u8>;
+
+/// Match the scalar `add_cycles` LUT pick: 32-bit accesses use the
+/// 32-bit cycle row, otherwise the 16-bit row. EWRAM in particular has
+/// `n_cycles32 = 6` vs `n_cycles16 = 3`, so a 32-bit DMA into EWRAM
+/// must charge the 32-bit row to stay equivalent to the slow path.
+#[inline]
+fn pick_dma_cycle_counts(
+    luts: &CycleLookupTables,
+    page: usize,
+    word_size_bytes: u32,
+) -> (usize, usize) {
+    if word_size_bytes == 4 {
+        (luts.n_cycles32[page], luts.s_cycles32[page])
+    } else {
+        (luts.n_cycles16[page], luts.s_cycles16[page])
+    }
+}
+
 impl SchedulerConnect for SysBus {
     fn connect_scheduler(&mut self, scheduler: SharedScheduler) {
         self.scheduler = scheduler.clone();
@@ -245,16 +277,17 @@ impl SysBus {
     /// DMA fast path: if `src` and `dst` each sit in a contiguous, linearly
     /// addressable memory region we own (EWRAM / IWRAM / ROM-on-cartridge),
     /// and the transfer doesn't cross the region boundary, perform the copy
-    /// as a single `copy_from_slice` and advance the scheduler once for the
-    /// whole burst instead of calling `load_N` / `store_N` per word.
+    /// as a single `ptr::copy` and advance the scheduler once for the whole
+    /// burst instead of calling `load_N` / `store_N` per word.
     ///
     /// Returns `true` if the fast path handled the transfer; `false` means
     /// the caller must fall back to the scalar word-by-word loop.
     ///
     /// Matches the slow path's cycle accounting: first access is Non-Seq,
     /// subsequent accesses are Seq, counted for both the source fetch and
-    /// the destination store. VRAM/Palette/OAM/IO regions are deliberately
-    /// left to the slow path — they have side effects, mirroring rules, or
+    /// the destination store, picking the 32 vs 16 bit LUT row from
+    /// `word_size_bytes`. VRAM/Palette/OAM/IO regions are deliberately left
+    /// to the slow path — they have side effects, mirroring rules, or
     /// privileged write gating that a raw copy would skip.
     pub fn dma_bulk_copy(
         &mut self,
@@ -272,35 +305,41 @@ impl SysBus {
         // allow writable RAM regions our fast path knows how to address.
         let byte_len = word_count * word_size_bytes;
 
-        // Returns (slice, starts_non_seq_cycles, seq_cycles) for the src region.
-        let src_region = self.resolve_bulk_src(src_addr, byte_len);
-        let Some((src_ptr_range, src_n_cycles, src_s_cycles)) = src_region else {
+        let Some(src) = self.resolve_bulk_src(src_addr, byte_len, word_size_bytes) else {
+            return false;
+        };
+        let Some(dst) = self.resolve_bulk_dst(dst_addr, byte_len, word_size_bytes) else {
             return false;
         };
 
-        let dst_region = self.resolve_bulk_dst(dst_addr, byte_len);
-        let Some((dst_ptr_range, dst_n_cycles, dst_s_cycles)) = dst_region else {
+        // Overlap check: src and dst may land in the same RAM region (e.g.
+        // legal in-place EWRAM-to-EWRAM shift like DMA3 0x02000100 ->
+        // 0x02000104). The scalar word-by-word loop produces "cascading"
+        // semantics where each store overwrites the next read's source —
+        // a memcpy/memmove would NOT match those bytes. Bail to the scalar
+        // path when the byte ranges actually overlap so behavior stays
+        // bit-identical with the slow path.
+        let src_start = src.ptr as usize;
+        let dst_start = dst.ptr as usize;
+        let len = byte_len as usize;
+        if src_start < dst_start + len && dst_start < src_start + len {
             return false;
-        };
+        }
 
-        // SAFETY: resolve_bulk_{src,dst} returned ranges inside distinct owned
-        // byte buffers (ewram, iwram, cartridge). We borrow them through raw
-        // pointers to avoid fighting the borrow checker over &self.* / &mut
-        // self.* on distinct fields. No aliasing: src is either in ROM (no
-        // aliasing possible) or in ewram/iwram distinct from dst's region.
+        // SAFETY: resolve_bulk_{src,dst} returned in-bounds offsets inside
+        // owned byte buffers (ewram, iwram, cartridge), and the overlap
+        // check above guarantees the source and destination byte ranges
+        // are disjoint, so copy_nonoverlapping is sound here.
         unsafe {
-            std::ptr::copy_nonoverlapping(
-                src_ptr_range,
-                dst_ptr_range,
-                byte_len as usize,
-            );
+            std::ptr::copy_nonoverlapping(src.ptr, dst.ptr, len);
         }
 
         // Cycle accounting: one N + (count-1) S for each of the source fetch
-        // and the destination store, using the per-region widths from our
-        // cycle LUT (which the scalar path also uses via `add_cycles`).
-        let total_read_cycles = src_n_cycles + src_s_cycles * (word_count as usize - 1);
-        let total_write_cycles = dst_n_cycles + dst_s_cycles * (word_count as usize - 1);
+        // and the destination store, using the per-region per-width values
+        // from our cycle LUT (which the scalar path also uses via
+        // `add_cycles`).
+        let total_read_cycles = src.n_cycles + src.s_cycles * (word_count as usize - 1);
+        let total_write_cycles = dst.n_cycles + dst.s_cycles * (word_count as usize - 1);
         self.scheduler.update(total_read_cycles + total_write_cycles);
 
         // RAM regions can hold executable code — any write may invalidate a
@@ -314,39 +353,33 @@ impl SysBus {
         true
     }
 
-    /// Resolve a source DMA address into a (raw-ptr, n-cycles, s-cycles)
-    /// triple. Returns None if the address doesn't fall in a region we can
-    /// fast-path or if the length would overflow the region.
+    /// Resolve a source DMA address into a `BulkSrc` (pointer + per-access
+    /// cycle counts). Returns None if the address doesn't fall in a region
+    /// we can fast-path or if the length would overflow the region.
     fn resolve_bulk_src(
         &self,
         src_addr: u32,
         byte_len: u32,
-    ) -> Option<(*const u8, usize, usize)> {
+        word_size_bytes: u32,
+    ) -> Option<BulkSrc> {
         let page = ((src_addr >> 24) & 0xF) as usize;
+        let (n_cycles, s_cycles) = pick_dma_cycle_counts(&self.cycle_luts, page, word_size_bytes);
         match src_addr & 0xff000000 {
             EWRAM_ADDR => {
-                let off = (src_addr & 0x3_ffff) as usize;
+                let off = (src_addr as usize) & (WORK_RAM_SIZE - 1);
                 if off + byte_len as usize > self.ewram.len() {
                     return None;
                 }
-                let p = unsafe { self.ewram.as_ptr().add(off) };
-                Some((
-                    p,
-                    self.cycle_luts.n_cycles16[page],
-                    self.cycle_luts.s_cycles16[page],
-                ))
+                let ptr = unsafe { self.ewram.as_ptr().add(off) };
+                Some(BulkRegion { ptr, n_cycles, s_cycles })
             }
             IWRAM_ADDR => {
-                let off = (src_addr & 0x7fff) as usize;
+                let off = (src_addr as usize) & (INTERNAL_RAM_SIZE - 1);
                 if off + byte_len as usize > self.iwram.len() {
                     return None;
                 }
-                let p = unsafe { self.iwram.as_ptr().add(off) };
-                Some((
-                    p,
-                    self.cycle_luts.n_cycles16[page],
-                    self.cycle_luts.s_cycles16[page],
-                ))
+                let ptr = unsafe { self.iwram.as_ptr().add(off) };
+                Some(BulkRegion { ptr, n_cycles, s_cycles })
             }
             // ROM: read-only, side-effect-free, but we must be careful not to
             // cross a 128 KiB "force-non-seq" cartridge boundary (GBATEK). For
@@ -366,12 +399,8 @@ impl SysBus {
                 if off + byte_len as usize > rom.len() {
                     return None;
                 }
-                let p = unsafe { rom.as_ptr().add(off) };
-                Some((
-                    p,
-                    self.cycle_luts.n_cycles16[page],
-                    self.cycle_luts.s_cycles16[page],
-                ))
+                let ptr = unsafe { rom.as_ptr().add(off) };
+                Some(BulkRegion { ptr, n_cycles, s_cycles })
             }
             _ => None,
         }
@@ -382,32 +411,33 @@ impl SysBus {
         &mut self,
         dst_addr: u32,
         byte_len: u32,
-    ) -> Option<(*mut u8, usize, usize)> {
+        _word_size_bytes: u32,
+    ) -> Option<BulkDst> {
         let page = ((dst_addr >> 24) & 0xF) as usize;
+        // TODO: this should match `_word_size_bytes` like resolve_bulk_src
+        // does, but the scalar `store_32` and `store_16` impls (sysbus.rs:752,
+        // 758) both call `add_cycles` with `MemoryAccessWidth::MemoryAccess8`
+        // which routes to the 16-bit cycle row regardless of width. To stay
+        // bit-identical with the scalar path (the whole point of the fast
+        // path), we mirror that quirk here. Fix the scalar `store_*` impls
+        // first, then promote this to width-correct in a follow-up.
+        let (n_cycles, s_cycles) = pick_dma_cycle_counts(&self.cycle_luts, page, 2);
         match dst_addr & 0xff000000 {
             EWRAM_ADDR => {
-                let off = (dst_addr & 0x3_ffff) as usize;
+                let off = (dst_addr as usize) & (WORK_RAM_SIZE - 1);
                 if off + byte_len as usize > self.ewram.len() {
                     return None;
                 }
-                let p = unsafe { self.ewram.as_mut_ptr().add(off) };
-                Some((
-                    p,
-                    self.cycle_luts.n_cycles16[page],
-                    self.cycle_luts.s_cycles16[page],
-                ))
+                let ptr = unsafe { self.ewram.as_mut_ptr().add(off) };
+                Some(BulkRegion { ptr, n_cycles, s_cycles })
             }
             IWRAM_ADDR => {
-                let off = (dst_addr & 0x7fff) as usize;
+                let off = (dst_addr as usize) & (INTERNAL_RAM_SIZE - 1);
                 if off + byte_len as usize > self.iwram.len() {
                     return None;
                 }
-                let p = unsafe { self.iwram.as_mut_ptr().add(off) };
-                Some((
-                    p,
-                    self.cycle_luts.n_cycles16[page],
-                    self.cycle_luts.s_cycles16[page],
-                ))
+                let ptr = unsafe { self.iwram.as_mut_ptr().add(off) };
+                Some(BulkRegion { ptr, n_cycles, s_cycles })
             }
             _ => None,
         }
@@ -722,5 +752,207 @@ impl MemoryInterface for SysBus {
 impl DmaNotifer for SysBus {
     fn notify(&mut self, timing: u16) {
         self.io.dmac.notify_from_gpu(timing);
+    }
+}
+
+#[cfg(test)]
+mod dma_bulk_tests {
+    //! Equivalence tests for `dma_bulk_copy`: for each region/size combo
+    //! we exercise, run BOTH the fast path and a hand rolled scalar
+    //! `load_N` / `store_N` loop on identical pre states, then assert
+    //! the destination bytes and the scheduler delta agree. Catches:
+    //!  - cycle accounting drift (16-bit row used for 32-bit DMA, etc)
+    //!  - aliasing / overlap UB if `copy_nonoverlapping` ever returns
+    //!  - region resolver off-by-one (boundary, wraparound mask)
+    use super::*;
+    use crate::cartridge::GamepakBuilder;
+    use crate::sound::interface::DynAudioInterface;
+    use crate::sound::interface::SimpleAudioInterface;
+
+    /// Smallest valid GBA cartridge header so `GamepakBuilder` accepts
+    /// the ROM. Most fields are zeroed; we only need the magic so the
+    /// build doesn't fail. ROM body is whatever caller provides.
+    fn build_test_rom(size: usize) -> Vec<u8> {
+        let mut rom = vec![0u8; size.max(0xc0)];
+        // Header is mostly don't care, but the entry-point branch and
+        // the Nintendo logo (0x04..=0x9f) are checksum-relevant. The
+        // GamepakBuilder does basic sanity, no checksum, so we skip the
+        // logo. Game title at 0xa0..=0xab, code at 0xac..=0xaf, "GBA "
+        // is enough.
+        rom[0xa0..0xa0 + 4].copy_from_slice(b"TEST");
+        rom[0xac..0xac + 4].copy_from_slice(b"TEST");
+        rom
+    }
+
+    fn make_test_sysbus() -> SysBus {
+        // Minimal viable construction. We just need the cycle LUTs, the
+        // ewram/iwram buffers, and a working scheduler. No CPU is
+        // attached, so any code path that touches arm_core would panic
+        // — dma_bulk_copy doesn't.
+        let bios = vec![0u8; 0x4000].into_boxed_slice();
+        let rom = build_test_rom(0x10_0000); // 1 MiB
+        let cartridge = GamepakBuilder::new()
+            .take_buffer(rom.into_boxed_slice())
+            .with_sram()
+            .without_backup_to_file()
+            .build()
+            .unwrap();
+
+        let scheduler = Scheduler::new_shared();
+        let (audio, _) = SimpleAudioInterface::create_channel(44100, None);
+        let audio_iface: DynAudioInterface = Box::new(*audio);
+        let io = Shared::new(IoDevices::new(
+            crate::interrupt::InterruptController::new(std::rc::Rc::new(std::cell::Cell::new(
+                crate::interrupt::IrqBitmask(0),
+            ))),
+            Box::new(crate::gpu::Gpu::new(
+                &mut scheduler.clone(),
+                std::rc::Rc::new(std::cell::Cell::new(crate::interrupt::IrqBitmask(0))),
+            )),
+            crate::dma::DmaController::new(std::rc::Rc::new(std::cell::Cell::new(
+                crate::interrupt::IrqBitmask(0),
+            ))),
+            crate::timer::Timers::new(std::rc::Rc::new(std::cell::Cell::new(
+                crate::interrupt::IrqBitmask(0),
+            ))),
+            Box::new(crate::sound::SoundController::new(
+                &mut scheduler.clone(),
+                audio_iface.get_sample_rate() as f32,
+            )),
+            scheduler.clone(),
+        ));
+        SysBus::new(scheduler, io, bios, cartridge)
+    }
+
+    /// Hand-rolled scalar equivalent to dma.rs's word loop, run against
+    /// `sb`'s actual buses + scheduler so cycle accounting goes through
+    /// the same `add_cycles` LUT path the production code uses.
+    fn scalar_dma(sb: &mut SysBus, src: u32, dst: u32, count: u32, word_size: u32) {
+        let mut access = MemoryAccess::NonSeq;
+        for i in 0..count {
+            let s = src + i * word_size;
+            let d = dst + i * word_size;
+            if word_size == 4 {
+                let v = sb.load_32(s & !3, access);
+                sb.store_32(d & !3, v, access);
+            } else {
+                let v = sb.load_16(s & !1, access);
+                sb.store_16(d & !1, v, access);
+            }
+            access = MemoryAccess::Seq;
+        }
+    }
+
+    fn fill_ewram(sb: &mut SysBus, off: usize, pattern: u8, len: usize) {
+        for i in 0..len {
+            sb.ewram[off + i] = pattern.wrapping_add(i as u8);
+        }
+    }
+
+    /// Read back a window of EWRAM as bytes for cmp.
+    fn snapshot_ewram(sb: &SysBus, off: usize, len: usize) -> Vec<u8> {
+        sb.ewram[off..off + len].to_vec()
+    }
+
+    #[test]
+    fn ewram_to_ewram_32bit_matches_scalar() {
+        let count: u32 = 128;
+        let word_size: u32 = 4;
+        let src = EWRAM_ADDR + 0x100;
+        let dst = EWRAM_ADDR + 0x800;
+
+        let mut sb_fast = make_test_sysbus();
+        fill_ewram(&mut sb_fast, 0x100, 0x10, (count * word_size) as usize);
+        let t_before_fast = sb_fast.scheduler.timestamp();
+        let handled = sb_fast.dma_bulk_copy(src, dst, count, word_size);
+        assert!(handled, "fast path should handle this");
+        let cycles_fast = sb_fast.scheduler.timestamp() - t_before_fast;
+        let bytes_fast = snapshot_ewram(&sb_fast, 0x800, (count * word_size) as usize);
+
+        let mut sb_scalar = make_test_sysbus();
+        fill_ewram(&mut sb_scalar, 0x100, 0x10, (count * word_size) as usize);
+        let t_before_scalar = sb_scalar.scheduler.timestamp();
+        scalar_dma(&mut sb_scalar, src, dst, count, word_size);
+        let cycles_scalar = sb_scalar.scheduler.timestamp() - t_before_scalar;
+        let bytes_scalar = snapshot_ewram(&sb_scalar, 0x800, (count * word_size) as usize);
+
+        assert_eq!(bytes_fast, bytes_scalar, "destination bytes must match scalar");
+        assert_eq!(
+            cycles_fast, cycles_scalar,
+            "scheduler delta must match scalar (the bug: 32-bit DMA was using the 16-bit cycle row)"
+        );
+    }
+
+    #[test]
+    fn ewram_to_ewram_16bit_matches_scalar() {
+        let count: u32 = 64;
+        let word_size: u32 = 2;
+        let src = EWRAM_ADDR + 0x40;
+        let dst = EWRAM_ADDR + 0x400;
+
+        let mut sb_fast = make_test_sysbus();
+        fill_ewram(&mut sb_fast, 0x40, 0x55, (count * word_size) as usize);
+        let t0 = sb_fast.scheduler.timestamp();
+        assert!(sb_fast.dma_bulk_copy(src, dst, count, word_size));
+        let cycles_fast = sb_fast.scheduler.timestamp() - t0;
+        let bytes_fast = snapshot_ewram(&sb_fast, 0x400, (count * word_size) as usize);
+
+        let mut sb_scalar = make_test_sysbus();
+        fill_ewram(&mut sb_scalar, 0x40, 0x55, (count * word_size) as usize);
+        let t0 = sb_scalar.scheduler.timestamp();
+        scalar_dma(&mut sb_scalar, src, dst, count, word_size);
+        let cycles_scalar = sb_scalar.scheduler.timestamp() - t0;
+        let bytes_scalar = snapshot_ewram(&sb_scalar, 0x400, (count * word_size) as usize);
+
+        assert_eq!(bytes_fast, bytes_scalar);
+        assert_eq!(cycles_fast, cycles_scalar);
+    }
+
+    #[test]
+    fn ewram_to_ewram_overlapping_forward_bails_to_scalar() {
+        // Forward shift inside one EWRAM region: src=0x100, dst=0x108,
+        // count=64 (32-bit). Source and dest byte ranges overlap. The
+        // GBA-correct semantic is the scalar word-by-word "cascading"
+        // copy where each store overwrites the next read's source —
+        // a memmove would NOT match those bytes, and copy_nonoverlapping
+        // would be UB. The fast path must bail to the scalar loop in
+        // this case.
+        let count: u32 = 64;
+        let word_size: u32 = 4;
+        let src = EWRAM_ADDR + 0x100;
+        let dst = EWRAM_ADDR + 0x108;
+
+        let mut sb = make_test_sysbus();
+        fill_ewram(&mut sb, 0x100, 0xa0, ((count + 4) * word_size) as usize);
+        assert!(
+            !sb.dma_bulk_copy(src, dst, count, word_size),
+            "overlapping ewram-to-ewram DMA must fall through to the scalar path \
+             so the cascading word-by-word semantics are preserved"
+        );
+    }
+
+    #[test]
+    fn ewram_to_iwram_32bit_matches_scalar() {
+        let count: u32 = 32;
+        let word_size: u32 = 4;
+        let src = EWRAM_ADDR + 0x200;
+        let dst = IWRAM_ADDR + 0x100;
+
+        let mut sb_fast = make_test_sysbus();
+        fill_ewram(&mut sb_fast, 0x200, 0xc3, (count * word_size) as usize);
+        let t0 = sb_fast.scheduler.timestamp();
+        assert!(sb_fast.dma_bulk_copy(src, dst, count, word_size));
+        let cycles_fast = sb_fast.scheduler.timestamp() - t0;
+        let dst_bytes_fast = sb_fast.iwram[0x100..0x100 + (count * word_size) as usize].to_vec();
+
+        let mut sb_scalar = make_test_sysbus();
+        fill_ewram(&mut sb_scalar, 0x200, 0xc3, (count * word_size) as usize);
+        let t0 = sb_scalar.scheduler.timestamp();
+        scalar_dma(&mut sb_scalar, src, dst, count, word_size);
+        let cycles_scalar = sb_scalar.scheduler.timestamp() - t0;
+        let dst_bytes_scalar = sb_scalar.iwram[0x100..0x100 + (count * word_size) as usize].to_vec();
+
+        assert_eq!(dst_bytes_fast, dst_bytes_scalar);
+        assert_eq!(cycles_fast, cycles_scalar);
     }
 }

--- a/core/src/sysbus.rs
+++ b/core/src/sysbus.rs
@@ -413,6 +413,9 @@ impl SysBus {
         }
     }
 
+    // Kept inline(always) so that load_{8,16,32}'s cycle accounting can
+    // propagate directly into the CPU's per instruction fetch instead of
+    // going through a regular call.
     #[inline(always)]
     pub fn add_cycles(&mut self, addr: Addr, access: MemoryAccess, width: MemoryAccessWidth) {
         use MemoryAccess::*;
@@ -479,7 +482,7 @@ impl SysBus {
 
 /// Todo - implement bound checks for EWRAM/IWRAM
 impl BusIO for SysBus {
-    #[inline]
+    #[inline(always)]
     fn read_32(&mut self, addr: Addr) -> u32 {
         match addr & 0xff000000 {
             BIOS_ADDR => {


### PR DESCRIPTION
Split out of #195 so the pieces Michel can land independently are actually reviewable on their own. This PR carries **only** the perf work that lives on the default (non-gated) code path. No feature flags introduced, no behavior change for users on the default build beyond speed.

## What's in here

11 commits, smallest-blast-radius first:

- `dma: bulk-copy fast path bypasses per-word sysbus dispatch` — when src+dst are both writable-RAM (or src ROM, dst RAM) with incrementing strides, skips the per-word sysbus dispatch and does a direct `copy_nonoverlapping` plus one scheduler update. Cycle accounting stays bit-identical to the scalar loop.
- `gpu: finalize_pixel straight-line refactor` — replaces the closure-heavy `filter().take(2)` over backgrounds with an explicit loop over the fixed 4-BG upper bound, so LLVM unrolls it.
- `gpu: inline hints on Rgb15 hot methods`
- `gpu: use slice::fill for obj_buffer_reset`
- `cartridge: override BusIO::read_32 with a direct u32 read for ROM` — default trait impl does two `read_16` calls; for in-bounds ROM that's not GPIO/EEPROM, one 4-byte read is correct and cheaper.
- `cpu: tighten inline on step()`
- `perf: inline(always) on inner dispatch hot path` — `single_step`, `cpu_step`, `dma_step`, `cpu_interrupt`, `irq_pending`, `dma.is_active`, scheduler timestamp/peek. All fire in the per-instruction inner loop.
- `sysbus: inline(always) on read_32 + add_cycles hot path`
- `gpu: inline(always) on finalize_pixel`
- `gpu: inline(always) on read_pixel_index_bpp4/bpp8`
- `sysbus: inline(always) on read_16` — perf-guided; `perf record` on the pokeemerald replay shows `SysBus::load_16` dispatch at ~30% of CPU self time. Match the treatment `read_32` already got.

## Verification

- `cargo test --workspace --lib --bins --tests --release` — 13 gba-tests pass, no new regressions. Pre-existing broken doctest in `arm7tdmi/src/memory.rs` (pseudocode misformatted as a runnable doctest) is unrelated; flagged separately.
- `fps_bench` replay on a 256s pokeemerald recording (title → overworld → menus) moves from upstream-master baseline ~877 FPS to ~1300 FPS on this branch's default build. That's the non-PGO, non-cache, non-JIT number.

## Not in this PR

- `cached_interp` feature work (separate PR)
- `dynarec` feature work (separate PR, depends on cached_interp)
- PGO build scripts (separate PR)
- On-device APK record/replay (separate PR)

Splits out of #195 per your review request.