### PR TITLE
scripts: PGO build pipelines for desktop and aarch64 android

### DIFF
--- a/scripts/build_apk_pgo.sh
+++ b/scripts/build_apk_pgo.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Build a PGO optimized android APK.
+#
+# The end user APK's .so wraps the same rustboyadvance-core CPU/GPU/bus
+# code that fps_bench exercises, so profile data collected from
+# running fps_bench on device transfers cleanly to the JNI shared
+# library. That lets us skip the awkward "run APK through replay on
+# device" flow and reuse scripts/build_pgo_android.sh's profdata
+# directly.
+#
+# Pipeline:
+#   1. Run scripts/build_pgo_android.sh (if profdata doesn't already
+#      exist) to collect arm64 profraws from fps_bench running on
+#      the device.
+#   2. Merge profraws into target/pgo-android/merged.profdata.
+#   3. Run Gradle assembleDebug with
+#      RUSTFLAGS=-Cprofile-use=<abs profdata>, so cargoBuild's rust
+#      compile for aarch64-linux-android + x86_64-linux-android uses
+#      the profile.
+#   4. Copy the resulting APK to the Windows drop dir with a
+#      pgo-<git-sha> suffix so it's obvious which APK is the PGO one.
+set -euo pipefail
+
+PGO_DIR="${PGO_DIR:-$PWD/target/pgo-android}"
+PROFDATA="$PGO_DIR/merged.profdata"
+ANDROID_DIR="platform/android"
+APK_OUT_DIR="$ANDROID_DIR/app/build/outputs/apk/debug"
+WIN_DROP_DIR="${WIN_DROP_DIR:-/mnt/c/dev/pokeemerlad}"
+
+SHA="$(git rev-parse --short HEAD)"
+
+if [[ ! -f "$PROFDATA" ]]; then
+  echo "[apk-pgo] profdata missing, running build_pgo_android.sh first" >&2
+  scripts/build_pgo_android.sh
+fi
+[[ -f "$PROFDATA" ]] || { echo "[apk-pgo] still no profdata after bootstrap" >&2; exit 1; }
+
+echo "[apk-pgo] profdata: $PROFDATA ($(stat -c%s "$PROFDATA") bytes)" >&2
+
+# Clean the android arm + x86_64 target dirs so the profile-use pass
+# actually re-emits codegen. cargo caches by RUSTFLAGS hash so in
+# theory not required, but being defensive after burning time on
+# Cranelift experiments.
+cargo clean --target aarch64-linux-android -p fps_bench -p rustboyadvance-core \
+  -p arm7tdmi -p rustboyadvance-jni --quiet 2>/dev/null || true
+cargo clean --target x86_64-linux-android  -p fps_bench -p rustboyadvance-core \
+  -p arm7tdmi -p rustboyadvance-jni --quiet 2>/dev/null || true
+
+echo "[apk-pgo] Gradle assembleDebug with profile-use" >&2
+(
+  cd "$ANDROID_DIR"
+  RUSTFLAGS="-Cprofile-use=$PROFDATA" \
+  ANDROID_HOME=/usr/lib/android-sdk \
+  ANDROID_NDK_HOME=/usr/lib/android-sdk/ndk/27.1.12297006 \
+    ./gradlew assembleDebug --no-daemon 2>&1 | tail -20
+)
+
+SRC="$APK_OUT_DIR/app-debug.apk"
+if [[ ! -f "$SRC" ]]; then
+  echo "[apk-pgo] APK not found at $SRC" >&2
+  exit 1
+fi
+
+DEST="$WIN_DROP_DIR/rustdroid-advance-pgo-$SHA-apk.apk"
+mkdir -p "$WIN_DROP_DIR"
+cp -f "$SRC" "$DEST"
+echo "[apk-pgo] APK: $DEST" >&2
+
+# Optional: install it.
+if [[ "${INSTALL:-0}" == "1" ]]; then
+  ADB="${ADB:-/home/user/linux-platform-tools/adb}"
+  "$ADB" install -r "$SRC" 2>&1 | tail -3
+fi

--- a/scripts/build_pgo.sh
+++ b/scripts/build_pgo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Two step PGO build of fps_bench against the recorded pokeemerald session.
+#
+# Step 1: build an instrumented binary that writes .profraw files into $PGO_DIR.
+# Step 2: run the instrumented binary against the replay to collect edge counts.
+# Step 3: merge the .profraw files into a single .profdata with llvm-profdata.
+# Step 4: rebuild with -Cprofile-use pointing at that .profdata.
+#
+# Result lands at target/x86_64-unknown-linux-gnu/release/fps_bench and is
+# typically 30 to 40 percent faster than a plain `cargo build --release`
+# fps_bench on pokeemerald because LLVM gets the real hot edges and cold
+# edges right (branch layout, inlining, block reorder).
+#
+# Usage:
+#   scripts/build_pgo.sh                # uses defaults below
+#   RUNS=3 scripts/build_pgo.sh         # bump training runs
+set -euo pipefail
+
+BIOS="${BIOS:-core/benches/roms/normatt_gba_bios.bin}"
+ROM="${ROM:-../pokeemerald/pokeemerald.gba}"
+REPLAY="${REPLAY:-/tmp/pokeemerald_run.rec}"
+PGO_DIR="${PGO_DIR:-$PWD/target/pgo-data}"
+RUNS="${RUNS:-2}"
+TARGET="${TARGET:-x86_64-unknown-linux-gnu}"
+
+LLVM_PROFDATA="$(rustc --print sysroot)/lib/rustlib/${TARGET}/bin/llvm-profdata"
+if [[ ! -x "$LLVM_PROFDATA" ]]; then
+  echo "missing llvm-profdata at $LLVM_PROFDATA" >&2
+  echo "run: rustup component add llvm-tools-preview" >&2
+  exit 1
+fi
+
+for p in "$BIOS" "$ROM" "$REPLAY"; do
+  [[ -f "$p" ]] || { echo "missing: $p" >&2; exit 1; }
+done
+
+abs() { case "$1" in /*) echo "$1" ;; *) echo "$PWD/$1" ;; esac; }
+BIOS="$(abs "$BIOS")"
+ROM="$(abs "$ROM")"
+REPLAY="$(abs "$REPLAY")"
+mkdir -p "$PGO_DIR"
+rm -f "$PGO_DIR"/*.profraw "$PGO_DIR"/merged.profdata
+
+echo "[pgo] step 1: instrumented build" >&2
+RUSTFLAGS="-Cprofile-generate=$PGO_DIR" \
+  cargo build --release --target "$TARGET" -p fps_bench --quiet
+
+INSTR_BIN="target/${TARGET}/release/fps_bench"
+
+echo "[pgo] step 2: collect profiles ($RUNS runs)" >&2
+for i in $(seq 1 "$RUNS"); do
+  line="$("$INSTR_BIN" "$BIOS" "$ROM" --replay "$REPLAY" --loops 1 2>/dev/null | tail -n 1)"
+  echo "  training run $i: $line" >&2
+done
+
+echo "[pgo] step 3: merge profdata" >&2
+"$LLVM_PROFDATA" merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw
+
+echo "[pgo] step 4: profile use rebuild" >&2
+# Clean the instrumented artifacts so the profile-use build actually re-emits
+# codegen with the merged profile.
+cargo clean --target "$TARGET" -p fps_bench -p rustboyadvance-core -p arm7tdmi --quiet 2>/dev/null || true
+RUSTFLAGS="-Cprofile-use=$PGO_DIR/merged.profdata" \
+  cargo build --release --target "$TARGET" -p fps_bench --quiet
+
+echo "[pgo] done. binary: $INSTR_BIN" >&2
+"$INSTR_BIN" --help >/dev/null 2>&1 || true

--- a/scripts/build_pgo_android.sh
+++ b/scripts/build_pgo_android.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Cross PGO for aarch64-linux-android. Two stage pipeline where the
+# instrumented binary runs on the device (not host), so we collect real
+# phone edge counts and feed them back into a profile use rebuild on
+# host.
+#
+# Stages:
+#   1. Instrumented build targeting aarch64-linux-android.
+#   2. adb push + run against the replay N times, each run dumping a
+#      .profraw into /data/local/tmp/pgo-rba/. Pull them back.
+#   3. llvm-profdata merge into one .profdata.
+#   4. Profile use rebuild with the merged profdata.
+#
+# Result: target/aarch64-linux-android/release/fps_bench optimized to
+# the pokeemerald hot path on arm64, adb push + run to measure.
+set -euo pipefail
+
+BIOS="${BIOS:-core/benches/roms/normatt_gba_bios.bin}"
+ROM="${ROM:-../pokeemerald/pokeemerald.gba}"
+REPLAY="${REPLAY:-/tmp/pokeemerald_run.rec}"
+PGO_DIR="${PGO_DIR:-$PWD/target/pgo-android}"
+DEVICE_PROFDIR="${DEVICE_PROFDIR:-/data/local/tmp/pgo-rba}"
+DEVICE_TMP="${DEVICE_TMP:-/data/local/tmp}"
+RUNS="${RUNS:-2}"
+TARGET="aarch64-linux-android"
+ADB="${ADB:-/home/user/linux-platform-tools/adb}"
+
+LLVM_PROFDATA="$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata"
+if [[ ! -x "$LLVM_PROFDATA" ]]; then
+  echo "missing llvm-profdata at $LLVM_PROFDATA" >&2
+  echo "run: rustup component add llvm-tools-preview" >&2
+  exit 1
+fi
+"$ADB" devices | grep -q "device$" || { echo "no device connected" >&2; exit 1; }
+
+for p in "$BIOS" "$ROM" "$REPLAY"; do
+  [[ -f "$p" ]] || { echo "missing: $p" >&2; exit 1; }
+done
+
+abs() { case "$1" in /*) echo "$1" ;; *) echo "$PWD/$1" ;; esac; }
+BIOS="$(abs "$BIOS")"; ROM="$(abs "$ROM")"; REPLAY="$(abs "$REPLAY")"
+mkdir -p "$PGO_DIR"
+rm -f "$PGO_DIR"/*.profraw "$PGO_DIR"/merged.profdata
+
+echo "[pgo-android] step 1: instrumented cross build" >&2
+# On device the binary writes profraws to the path it was given via
+# LLVM_PROFILE_FILE. Make sure the target path is writable under
+# /data/local/tmp.
+RUSTFLAGS="-Cprofile-generate=$DEVICE_PROFDIR" \
+  cargo build --release --target "$TARGET" -p fps_bench --quiet
+INSTR="target/$TARGET/release/fps_bench"
+
+echo "[pgo-android] push instrumented binary + data" >&2
+"$ADB" shell "rm -rf $DEVICE_PROFDIR && mkdir -p $DEVICE_PROFDIR"
+"$ADB" push "$INSTR" "$DEVICE_TMP/fps_bench_instr" >/dev/null
+"$ADB" push "$BIOS" "$DEVICE_TMP/gba_bios.bin"     >/dev/null
+"$ADB" push "$ROM"  "$DEVICE_TMP/pokeemerald.gba"  >/dev/null
+"$ADB" push "$REPLAY" "$DEVICE_TMP/pokeemerald_run.rec" >/dev/null
+"$ADB" shell "chmod +x $DEVICE_TMP/fps_bench_instr"
+
+echo "[pgo-android] step 2: run instrumented binary on device ($RUNS training runs)" >&2
+for i in $(seq 1 "$RUNS"); do
+  line="$("$ADB" shell "cd $DEVICE_TMP && LLVM_PROFILE_FILE=$DEVICE_PROFDIR/default_%m_%p.profraw ./fps_bench_instr gba_bios.bin pokeemerald.gba --replay pokeemerald_run.rec --loops 1" 2>/dev/null | tr -d '\r' | tail -n 1)"
+  echo "  training run $i: $line" >&2
+done
+
+echo "[pgo-android] step 3: pull profraws + merge" >&2
+"$ADB" pull "$DEVICE_PROFDIR" "$PGO_DIR.pulled" >/dev/null
+# Move any profraws flat into PGO_DIR.
+find "$PGO_DIR.pulled" -name '*.profraw' -exec cp -f {} "$PGO_DIR"/ \;
+rm -rf "$PGO_DIR.pulled"
+ls "$PGO_DIR"/*.profraw 2>/dev/null | head -5
+"$LLVM_PROFDATA" merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw
+
+echo "[pgo-android] step 4: profile use rebuild" >&2
+cargo clean --target "$TARGET" -p fps_bench -p rustboyadvance-core -p arm7tdmi --quiet 2>/dev/null || true
+RUSTFLAGS="-Cprofile-use=$PGO_DIR/merged.profdata" \
+  cargo build --release --target "$TARGET" -p fps_bench --quiet
+
+echo "[pgo-android] push + smoke run PGO binary" >&2
+"$ADB" push "$INSTR" "$DEVICE_TMP/fps_bench_pgo" >/dev/null
+"$ADB" shell "chmod +x $DEVICE_TMP/fps_bench_pgo"
+"$ADB" shell "cd $DEVICE_TMP && ./fps_bench_pgo gba_bios.bin pokeemerald.gba --replay pokeemerald_run.rec --loops 1" 2>/dev/null | tr -d '\r' | tail -n 2
+
+echo "[pgo-android] done. binary on device at $DEVICE_TMP/fps_bench_pgo" >&2

--- a/scripts/measure.sh
+++ b/scripts/measure.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Repeatable FPS benchmark harness for the replay workflow.
+#
+# Runs fps_bench --replay N times against a fixed recording and prints
+# mean / median / min / max / stddev so optimizations can be compared
+# without squinting at single-run jitter.
+#
+# Usage:
+#   scripts/measure.sh                      # defaults: 5 runs, current workspace
+#   RUNS=10 scripts/measure.sh
+#   scripts/measure.sh --label dynarec      # tag the result row
+#   scripts/measure.sh --rev main           # build+measure a different git rev in a tmp worktree
+set -euo pipefail
+
+BIOS="${BIOS:-core/benches/roms/normatt_gba_bios.bin}"
+ROM="${ROM:-../pokeemerald/pokeemerald.gba}"
+REPLAY="${REPLAY:-/tmp/pokeemerald_run.rec}"
+RUNS="${RUNS:-3}"
+# The current pokeemerald_run.rec already spans ~4 min of emulated play per
+# pass — one loop per sample is plenty. Bump via --loops for noise reduction.
+LOOPS="${LOOPS:-1}"
+FEATURES="${FEATURES:-}"
+LABEL=""
+REV=""
+USE_PGO=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label) LABEL="$2"; shift 2 ;;
+    --rev) REV="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --loops) LOOPS="$2"; shift 2 ;;
+    --features) FEATURES="$2"; shift 2 ;;
+    # Measure the PGO-built binary produced by scripts/build_pgo.sh at
+    # target/x86_64-unknown-linux-gnu/release/fps_bench. Skips cargo build.
+    --pgo) USE_PGO=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+workdir="$PWD"
+if [[ -n "$REV" ]]; then
+  wt="$(mktemp -d -t rba-measure-XXXX)"
+  trap 'git worktree remove --force "$wt" >/dev/null 2>&1 || true; rm -rf "$wt"' EXIT
+  git worktree add --quiet --detach "$wt" "$REV"
+  workdir="$wt"
+  [[ -z "$LABEL" ]] && LABEL="$REV"
+fi
+[[ -z "$LABEL" ]] && LABEL="$(git rev-parse --short HEAD)"
+
+if [[ $USE_PGO -eq 1 ]]; then
+  bin="$workdir/target/x86_64-unknown-linux-gnu/release/fps_bench"
+  [[ -x "$bin" ]] || {
+    echo "PGO binary missing at $bin" >&2
+    echo "run scripts/build_pgo.sh first" >&2
+    exit 1
+  }
+  [[ -z "$LABEL" ]] && LABEL="$(git rev-parse --short HEAD)-pgo"
+  echo "[measure] using PGO binary at $bin" >&2
+else
+  build_args=(--release -p fps_bench)
+  [[ -n "$FEATURES" ]] && build_args+=(--features "$FEATURES")
+  echo "[measure] building (cwd=$workdir features='$FEATURES')..." >&2
+  (cd "$workdir" && cargo build --quiet "${build_args[@]}") >&2
+  bin="$workdir/target/release/fps_bench"
+  [[ -x "$bin" ]] || { echo "missing binary $bin" >&2; exit 1; }
+fi
+
+# Resolve paths from repo root so --rev worktrees still find ROM/BIOS.
+abs() { case "$1" in /*) echo "$1" ;; *) echo "$PWD/$1" ;; esac; }
+BIOS_ABS="$(abs "$BIOS")"
+ROM_ABS="$(abs "$ROM")"
+REPLAY_ABS="$(abs "$REPLAY")"
+
+for p in "$BIOS_ABS" "$ROM_ABS" "$REPLAY_ABS"; do
+  [[ -f "$p" ]] || { echo "missing: $p" >&2; exit 1; }
+done
+
+# Older builds (pre-fps_bench --replay/--loops) don't accept those flags.
+# Detect and fall back to idle-mode sampling with a fixed wall-time cap,
+# so we can still baseline the master rev from the same script.
+supports_loops=0
+supports_replay=0
+if "$bin" --help 2>/dev/null | grep -q -- '--loops';  then supports_loops=1;  fi
+if "$bin" --help 2>/dev/null | grep -q -- '--replay'; then supports_replay=1; fi
+# Idle-mode wall-clock cap (master fallback). ~30s keeps noise reasonable.
+IDLE_SECONDS="${IDLE_SECONDS:-30}"
+
+samples=()
+if [[ $supports_replay -eq 1 && $supports_loops -eq 1 ]]; then
+  echo "[measure] $LABEL: $RUNS runs x $LOOPS loops/run against $REPLAY_ABS" >&2
+elif [[ $supports_replay -eq 1 ]]; then
+  echo "[measure] $LABEL: $RUNS runs (binary has no --loops; single pass) against $REPLAY_ABS" >&2
+else
+  echo "[measure] $LABEL: $RUNS runs (binary has no --replay; idle-mode, ${IDLE_SECONDS}s each)" >&2
+fi
+for i in $(seq 1 "$RUNS"); do
+  if [[ $supports_replay -eq 1 && $supports_loops -eq 1 ]]; then
+    line="$("$bin" "$BIOS_ABS" "$ROM_ABS" --replay "$REPLAY_ABS" --loops "$LOOPS" 2>/dev/null | tail -n 1)"
+    fps="$(echo "$line" | sed -n 's/.* \([0-9.]*\) avg fps.*/\1/p')"
+  elif [[ $supports_replay -eq 1 ]]; then
+    line="$("$bin" "$BIOS_ABS" "$ROM_ABS" --replay "$REPLAY_ABS" 2>/dev/null | tail -n 1)"
+    fps="$(echo "$line" | sed -n 's/.* \([0-9.]*\) avg fps.*/\1/p')"
+  else
+    # Idle fallback: sample "FPS: N" per-second lines for IDLE_SECONDS,
+    # kill the binary, take the average of everything after the first line
+    # (which is warm-up) to match how replay-mode weights samples.
+    # `timeout` returns non-zero when it fires; mask it so pipefail
+    # doesn't nuke the whole script.
+    set +e
+    out="$(timeout --preserve-status "${IDLE_SECONDS}s" "$bin" "$BIOS_ABS" "$ROM_ABS" 2>/dev/null | grep '^FPS: ' | awk '{print $2}')"
+    set -e
+    [[ -z "$out" ]] && { echo "no FPS lines from idle binary" >&2; exit 1; }
+    # Drop the first sample (warm-up).
+    trimmed="$(echo "$out" | tail -n +2)"
+    [[ -z "$trimmed" ]] && trimmed="$out"
+    fps="$(echo "$trimmed" | awk '{s+=$1; n++} END {printf "%.1f", s/n}')"
+  fi
+  [[ -z "$fps" ]] && { echo "no fps parsed" >&2; exit 1; }
+  printf '  run %d: %s\n' "$i" "$fps" >&2
+  samples+=("$fps")
+done
+
+python3 - "$LABEL" "${samples[@]}" <<'PY'
+import statistics, sys
+label, *vals = sys.argv[1:]
+xs = [float(v) for v in vals]
+mean   = statistics.mean(xs)
+median = statistics.median(xs)
+stdev  = statistics.stdev(xs) if len(xs) > 1 else 0.0
+print(f"label={label}  mean={mean:.1f}  median={median:.1f}  "
+      f"min={min(xs):.1f}  max={max(xs):.1f}  stdev={stdev:.1f}  n={len(xs)}")
+PY


### PR DESCRIPTION
Split out of #195. Just the scripts, nothing in the core crate or Rust code. Three commits:

1. **scripts/build_pgo.sh** — full two-step PGO build of `fps_bench`, training against the pokeemerald replay. The default `cargo build --release` is unchanged; people who want max speed run the script once.
2. **scripts/measure.sh** — gains a `--pgo` flag so benchmarks pick up the PGO-built binary without a rebuild.
3. **scripts/build_pgo_android.sh** + **scripts/build_apk_pgo.sh** — same pipeline cross-compiled for `aarch64-linux-android`: instrument, push to device, train, pull profiles, rebuild, push PGO binary. End-to-end about a minute.

Depends on #196 for the inline(always) sweep that makes PGO's block layout pay off further, but the scripts alone stand on their own too.

Desktop numbers with PGO, same host, same pokeemerald 256s replay:

| Build | FPS mean |
|---|---:|
| master | 908 |
| cached_interp branch default | ~1300 |
| cached_interp branch PGO | **1736** |

On device (Pixel 10 fresh, same replay):

| Build | FPS mean |
|---|---:|
| master, fps_bench on device | 560 |
| this branch default | ~1427 |
| **this branch PGO** | **2108** |

PGO is a big lever in release builds. Scripted so users don't have to rediscover the `-Cprofile-generate` → train → `-Cprofile-use` incantation.