### PR TITLE
jni + android: on-device keypad record/replay in the APK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,6 @@ jobs:
         path: target
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Setup Android NDK
-      run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
-
     - name: Build APK
       working-directory: ./platform/android
       run: ./gradlew assembleRelease

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,45 +58,57 @@ jobs:
         name: rustboyadvance-sdl2-x86_64-unknown-linux-gnu
         path: artifacts
 
-  # TODO: this workflow is stale
-  # build-android-apk:
+  build-android-apk:
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-  #   steps:
-  #   - name: Checkout 🛎️
-  #     uses: actions/checkout@v4
-  #     with:
-  #       submodules: recursive
-  #   - name: Install toolchains
-  #     run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
-  #   - name: Cache cargo registry
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: ~/.cargo/registry
-  #       key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-  #   - name: Cache cargo index
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: ~/.cargo/git
-  #       key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-  #   - name: Cache cargo build
-  #     uses: actions/cache@v4
-  #     with:
-  #       path: target
-  #       key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
 
-  #   - name: Build APK
-  #     working-directory: ./platform/android
-  #     run: ./gradlew assemble
-  #   - name: Upload artifacts
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: rustdroid.apk
-  #       path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
+    - name: Install Rust Android targets
+      run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-android-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo index
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-android-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo build
+      uses: actions/cache@v4
+      with:
+        path: target
+        key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Setup Android NDK
+      run: |
+        sdkmanager "ndk;27.2.12479018"
+        echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
+
+    - name: Build APK
+      working-directory: ./platform/android
+      run: ./gradlew assembleRelease
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: rustdroid.apk
+        path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
 
   build-windows-64:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,15 +96,26 @@ jobs:
         path: target
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Decode keystore
+      run: |
+        if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > ${{ runner.temp }}/release.keystore
+        fi
+
     - name: Build APK
       working-directory: ./platform/android
       run: ./gradlew assembleRelease
+      env:
+        KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
     - name: Upload APK
       uses: actions/upload-artifact@v4
       with:
         name: rustdroid.apk
-        path: ./platform/android/app/build/outputs/apk/release/app-release-unsigned.apk
+        path: ./platform/android/app/build/outputs/apk/release/app-release.apk
 
   build-windows-64:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,7 @@ jobs:
         key: ${{ runner.os }}-android-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Setup Android NDK
-      run: |
-        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "ndk;27.2.12479018"
-        echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
+      run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_HOME" >> $GITHUB_ENV
 
     - name: Build APK
       working-directory: ./platform/android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Setup Android NDK
       run: |
-        sdkmanager "ndk;27.2.12479018"
+        $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "ndk;27.2.12479018"
         echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> $GITHUB_ENV
 
     - name: Build APK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   build-linux:

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,34 +1,34 @@
-FROM npetrovsky/docker-android-sdk-ndk
+FROM ubuntu:22.04
 
-# Update default packages
-RUN apt-get update
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Get Ubuntu packages
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     build-essential \
-    curl
+    curl \
+    openjdk-17-jdk \
+    wget \
+    unzip
 
-# Update new packages
-RUN apt-get update
+# Install Android Command Line Tools
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+RUN mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+RUN wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/cmdline-tools.zip
+RUN unzip -q /tmp/cmdline-tools.zip -d $ANDROID_SDK_ROOT/cmdline-tools && \
+    mv $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest && \
+    rm /tmp/cmdline-tools.zip
+
+ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools
+
+# Accept licenses and install SDK packages
+RUN yes | sdkmanager --licenses
+RUN sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.2.12479018"
+
+ENV ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018
 
 # Get Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
-RUN . $HOME/.cargo/env && rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
-
-ENV NDK=$ANDROID_HOME/ndk-bundle
-
-RUN echo \
-        '[target.aarch64-linux-android]\n'\ 
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/aarch64-linux-android/bin/ar "\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang"\n'\
-        \
-        '[target.armv7-linux-androideabi]\n'\
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ar "\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi26-clang"\n'\
-        \
-        '[target.i686-linux-android]\n'\
-        'ar = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/i386-linux-android/bin/ar"\n'\
-        'linker = "/opt/android-sdk-linux/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"' > $HOME/.cargo/config
+RUN $HOME/.cargo/bin/rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android

--- a/core/src/gba.rs
+++ b/core/src/gba.rs
@@ -200,6 +200,14 @@ impl GameBoyAdvance {
         Ok(())
     }
 
+    /// Current emulated cycle timestamp. Used by the JNI record/replay
+    /// layer to stamp keypad edges so a playback line up exactly with
+    /// the cycle it was captured at.
+    #[inline]
+    pub fn cycles(&self) -> usize {
+        self.scheduler.timestamp()
+    }
+
     pub fn get_game_title(&self) -> String {
         self.sysbus.cartridge.header.game_title.clone()
     }

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -12,10 +12,25 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    signingConfigs {
+        release {
+            def keystoreFile = System.getenv("KEYSTORE_FILE")
+            if (keystoreFile != null && new File(keystoreFile).exists()) {
+                storeFile file(keystoreFile)
+                storePassword System.getenv("KEYSTORE_PASSWORD")
+                keyAlias System.getenv("KEY_ALIAS")
+                keyPassword System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            def keystoreFile = System.getenv("KEYSTORE_FILE")
+            if (keystoreFile != null && new File(keystoreFile).exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     compileOptions {

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -1,12 +1,14 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    namespace 'com.mrmichel.rustdroid_emu'
+    compileSdk 35
+    ndkVersion '27.1.12297006'
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdk 21
+        targetSdk 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -17,9 +19,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
-
-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 
 cargo {
     prebuiltToolchains = true
@@ -28,8 +32,9 @@ cargo {
     module = "../../../platform/rustboyadvance-jni"
     targetDirectory = '../../../target'
     libname = "rustboyadvance_jni"
-    targets = ['x86', 'arm64']
+    targets = ['x86_64', 'arm64']
     apiLevel = 21
+    pythonCommand = 'python3'
 }
 
 afterEvaluate {
@@ -40,20 +45,23 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        def mergeJni = tasks.findByName("merge${productFlavor}${buildType}JniLibFolders")
+        if (mergeJni != null) {
+            mergeJni.dependsOn(tasks["cargoBuild"])
+        }
     }
 }
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation "androidx.documentfile:documentfile:1.0.1"
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'commons-io:commons-io:2.6'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'commons-io:commons-io:2.14.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    namespace 'com.mrmichel.rustdroid_emu'
+    compileSdk 36
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
-        minSdkVersion 21
-        targetSdkVersion 26
+        minSdk 21
+        targetSdk 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -16,6 +16,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -40,20 +44,20 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["merge${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
     }
 }
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.documentfile:documentfile:1.0.1"
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'commons-io:commons-io:2.6'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'commons-io:commons-io:2.16.1'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/platform/android/app/build.gradle
+++ b/platform/android/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'com.mrmichel.rustdroid_emu'
     compileSdk 36
+    ndkVersion "27.3.13750724"
     defaultConfig {
         applicationId "com.mrmichel.rustdroid_emu"
         minSdk 21

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mrmichel.rustdroid_emu">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:glEsVersion="0x00200000"
         android:required="true" />
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:allowBackup="true"
@@ -30,20 +33,28 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <activity android:name=".ui.snapshots.SnapshotPickerActivity" />
+        <activity
+            android:name=".ui.snapshots.SnapshotPickerActivity"
+            android:exported="false" />
         <activity
             android:name=".ui.snapshots.SnapshotListFragment"
-            android:label="@string/title_activity_snapshot" />
+            android:label="@string/title_activity_snapshot"
+            android:exported="false" />
         <activity
             android:name=".ui.library.RomListActivity"
-            android:label="@string/title_activity_rom_list" />
+            android:label="@string/title_activity_rom_list"
+            android:exported="false" />
         <activity
             android:name=".ui.EmulatorActivity"
-            android:label="@string/title_activity_emulator" />
+            android:label="@string/title_activity_emulator"
+            android:exported="false" />
         <activity
             android:name=".ui.SettingsActivity"
-            android:label="Settings" />
-        <activity android:name=".ui.SplashActivity">
+            android:label="Settings"
+            android:exported="false" />
+        <activity
+            android:name=".ui.SplashActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mrmichel.rustdroid_emu">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:glEsVersion="0x00200000"
@@ -43,7 +42,9 @@
         <activity
             android:name=".ui.SettingsActivity"
             android:label="Settings" />
-        <activity android:name=".ui.SplashActivity">
+        <activity
+            android:name=".ui.SplashActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/platform/android/app/src/main/AndroidManifest.xml
+++ b/platform/android/app/src/main/AndroidManifest.xml
@@ -37,10 +37,6 @@
             android:name=".ui.snapshots.SnapshotPickerActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.snapshots.SnapshotListFragment"
-            android:label="@string/title_activity_snapshot"
-            android:exported="false" />
-        <activity
             android:name=".ui.library.RomListActivity"
             android:label="@string/title_activity_rom_list"
             android:exported="false" />

--- a/platform/android/app/src/main/java/com/mrmichel/rustboyadvance/EmulatorBindings.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustboyadvance/EmulatorBindings.java
@@ -118,9 +118,12 @@ public class EmulatorBindings {
     /**
      * Start recording keypad edges to the given file. Overwrites any
      * existing recording. File format is RBAREC01 which the SDL
-     * frontend and fps_bench can also consume.
+     * frontend and fps_bench can also consume. Returns true on success;
+     * false if the file could not be opened or the path was invalid.
+     * Caller must check the return before flipping any UI state — a
+     * "started recording" toast on a false return would be a lie.
      */
-    public static native void startRecording(long ctx, String path);
+    public static native boolean startRecording(long ctx, String path);
 
     /**
      * Flush and close an active recording session.
@@ -130,8 +133,10 @@ public class EmulatorBindings {
     /**
      * Load a recording file and start feeding its events into the
      * emulator. Overrides the Java keypad state until stopReplay.
+     * Returns true on success; false if the file is missing, unreadable,
+     * or the magic header doesn't match.
      */
-    public static native void startReplay(long ctx, String path);
+    public static native boolean startReplay(long ctx, String path);
 
     /**
      * Stop an active replay session.

--- a/platform/android/app/src/main/java/com/mrmichel/rustboyadvance/EmulatorBindings.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustboyadvance/EmulatorBindings.java
@@ -115,6 +115,29 @@ public class EmulatorBindings {
      */
     public static native void log(long ctx);
 
+    /**
+     * Start recording keypad edges to the given file. Overwrites any
+     * existing recording. File format is RBAREC01 which the SDL
+     * frontend and fps_bench can also consume.
+     */
+    public static native void startRecording(long ctx, String path);
+
+    /**
+     * Flush and close an active recording session.
+     */
+    public static native void stopRecording(long ctx);
+
+    /**
+     * Load a recording file and start feeding its events into the
+     * emulator. Overrides the Java keypad state until stopReplay.
+     */
+    public static native void startReplay(long ctx, String path);
+
+    /**
+     * Stop an active replay session.
+     */
+    public static native void stopReplay(long ctx);
+
     public class NativeBindingException extends Exception {
         public NativeBindingException(String errorMessage) {
             super(errorMessage);

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
@@ -75,37 +75,27 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
     @Override
     public boolean onTouch(View v, MotionEvent event) {
         Keypad.Key key = null;
-        switch (v.getId()) {
-            case R.id.bDpadUp:
-                key = Keypad.Key.Up;
-                break;
-            case R.id.bDpadDown:
-                key = Keypad.Key.Down;
-                break;
-            case R.id.bDpadLeft:
-                key = Keypad.Key.Left;
-                break;
-            case R.id.bDpadRight:
-                key = Keypad.Key.Right;
-                break;
-            case R.id.buttonA:
-                key = Keypad.Key.ButtonA;
-                break;
-            case R.id.buttonB:
-                key = Keypad.Key.ButtonB;
-                break;
-            case R.id.buttonL:
-                key = Keypad.Key.ButtonL;
-                break;
-            case R.id.buttonR:
-                key = Keypad.Key.ButtonR;
-                break;
-            case R.id.bStart:
-                key = Keypad.Key.Start;
-                break;
-            case R.id.bSelect:
-                key = Keypad.Key.Select;
-                break;
+        int vid = v.getId();
+        if (vid == R.id.bDpadUp) {
+            key = Keypad.Key.Up;
+        } else if (vid == R.id.bDpadDown) {
+            key = Keypad.Key.Down;
+        } else if (vid == R.id.bDpadLeft) {
+            key = Keypad.Key.Left;
+        } else if (vid == R.id.bDpadRight) {
+            key = Keypad.Key.Right;
+        } else if (vid == R.id.buttonA) {
+            key = Keypad.Key.ButtonA;
+        } else if (vid == R.id.buttonB) {
+            key = Keypad.Key.ButtonB;
+        } else if (vid == R.id.buttonL) {
+            key = Keypad.Key.ButtonL;
+        } else if (vid == R.id.buttonR) {
+            key = Keypad.Key.ButtonR;
+        } else if (vid == R.id.bStart) {
+            key = Keypad.Key.Start;
+        } else if (vid == R.id.bSelect) {
+            key = Keypad.Key.Select;
         }
         int action = event.getAction();
         if (key != null) {
@@ -409,25 +399,25 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_load_rom:
-                doLoadRom();
-                return true;
-            case R.id.action_view_snapshots:
-                doViewSnapshots();
-                return true;
-            case R.id.action_save_snapshot:
-                doSaveSnapshot();
-                return true;
-            case R.id.action_set_library_image:
-                doSaveScreenshotToLibrary();
-                return true;
-            case R.id.action_settings:
-                Intent intent = new Intent(this, SettingsActivity.class);
-                startActivity(intent);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_load_rom) {
+            doLoadRom();
+            return true;
+        } else if (id == R.id.action_view_snapshots) {
+            doViewSnapshots();
+            return true;
+        } else if (id == R.id.action_save_snapshot) {
+            doSaveSnapshot();
+            return true;
+        } else if (id == R.id.action_set_library_image) {
+            doSaveScreenshotToLibrary();
+            return true;
+        } else if (id == R.id.action_settings) {
+            Intent intent = new Intent(this, SettingsActivity.class);
+            startActivity(intent);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
@@ -54,6 +54,13 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
     private AndroidAudioPlayer audioPlayer;
     private byte[] on_resume_saved_state = null;
 
+    /// Fixed recording file path. Lives under the app's external Downloads
+    /// so it's easy to pull with adb or share. Users who want multiple
+    /// recordings rename the file between sessions.
+    private static final String REC_FILE_PATH = "/sdcard/Download/rbarec.rec";
+    private boolean isRecording = false;
+    private boolean isReplaying = false;
+
     private Emulator emulator;
     private ScreenView screenView;
     private CompoundButton turboButton;
@@ -393,6 +400,7 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
+        this.menu = menu;
         getMenuInflater().inflate(R.menu.menu_emulator, menu);
         return true;
     }
@@ -411,6 +419,12 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
             return true;
         } else if (id == R.id.action_set_library_image) {
             doSaveScreenshotToLibrary();
+            return true;
+        } else if (id == R.id.action_record_toggle) {
+            toggleRecording(item);
+            return true;
+        } else if (id == R.id.action_replay_toggle) {
+            toggleReplay(item);
             return true;
         } else if (id == R.id.action_settings) {
             Intent intent = new Intent(this, SettingsActivity.class);
@@ -474,6 +488,56 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
         screenView.onResume();
         resumeEmulation();
         audioPlayer.play();
+    }
+
+    private void toggleRecording(MenuItem item) {
+        if (!isEmulatorRunning()) {
+            Toast.makeText(this, "No game is running!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        long ctx = emulator.getCtx();
+        if (!isRecording) {
+            if (isReplaying) {
+                EmulatorBindings.stopReplay(ctx);
+                isReplaying = false;
+                MenuItem replayItem = menu.findItem(R.id.action_replay_toggle);
+                if (replayItem != null) replayItem.setTitle(R.string.action_replay_start);
+            }
+            EmulatorBindings.startRecording(ctx, REC_FILE_PATH);
+            isRecording = true;
+            item.setTitle(R.string.action_record_stop);
+            Toast.makeText(this, "Recording to " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+        } else {
+            EmulatorBindings.stopRecording(ctx);
+            isRecording = false;
+            item.setTitle(R.string.action_record_start);
+            Toast.makeText(this, "Recording saved", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void toggleReplay(MenuItem item) {
+        if (!isEmulatorRunning()) {
+            Toast.makeText(this, "No game is running!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        long ctx = emulator.getCtx();
+        if (!isReplaying) {
+            if (isRecording) {
+                EmulatorBindings.stopRecording(ctx);
+                isRecording = false;
+                MenuItem recItem = menu.findItem(R.id.action_record_toggle);
+                if (recItem != null) recItem.setTitle(R.string.action_record_start);
+            }
+            EmulatorBindings.startReplay(ctx, REC_FILE_PATH);
+            isReplaying = true;
+            item.setTitle(R.string.action_replay_stop);
+            Toast.makeText(this, "Replaying " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+        } else {
+            EmulatorBindings.stopReplay(ctx);
+            isReplaying = false;
+            item.setTitle(R.string.action_replay_start);
+            Toast.makeText(this, "Replay stopped", Toast.LENGTH_SHORT).show();
+        }
     }
 
     public void doSaveScreenshotToLibrary() {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/EmulatorActivity.java
@@ -503,10 +503,16 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
                 MenuItem replayItem = menu.findItem(R.id.action_replay_toggle);
                 if (replayItem != null) replayItem.setTitle(R.string.action_replay_start);
             }
-            EmulatorBindings.startRecording(ctx, REC_FILE_PATH);
-            isRecording = true;
-            item.setTitle(R.string.action_record_stop);
-            Toast.makeText(this, "Recording to " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+            // Only flip the UI state if the native side actually opened
+            // the file. Otherwise we'd lie via the menu label and the
+            // toast about a recording that never started.
+            if (EmulatorBindings.startRecording(ctx, REC_FILE_PATH)) {
+                isRecording = true;
+                item.setTitle(R.string.action_record_stop);
+                Toast.makeText(this, "Recording to " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Could not start recording (see logcat)", Toast.LENGTH_LONG).show();
+            }
         } else {
             EmulatorBindings.stopRecording(ctx);
             isRecording = false;
@@ -528,10 +534,14 @@ public class EmulatorActivity extends AppCompatActivity implements View.OnClickL
                 MenuItem recItem = menu.findItem(R.id.action_record_toggle);
                 if (recItem != null) recItem.setTitle(R.string.action_record_start);
             }
-            EmulatorBindings.startReplay(ctx, REC_FILE_PATH);
-            isReplaying = true;
-            item.setTitle(R.string.action_replay_stop);
-            Toast.makeText(this, "Replaying " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+            // Same as toggleRecording: only flip UI state on a true return.
+            if (EmulatorBindings.startReplay(ctx, REC_FILE_PATH)) {
+                isReplaying = true;
+                item.setTitle(R.string.action_replay_stop);
+                Toast.makeText(this, "Replaying " + REC_FILE_PATH, Toast.LENGTH_SHORT).show();
+            } else {
+                Toast.makeText(this, "Could not start replay (see logcat)", Toast.LENGTH_LONG).show();
+            }
         } else {
             EmulatorBindings.stopReplay(ctx);
             isReplaying = false;

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
@@ -1,23 +1,18 @@
 package com.mrmichel.rustdroid_emu.ui;
 
-import android.Manifest;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ConfigurationInfo;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Toast;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import com.mrmichel.rustdroid_emu.R;
 import com.mrmichel.rustdroid_emu.ui.library.RomListActivity;
@@ -31,30 +26,12 @@ import java.io.InputStream;
 public class SplashActivity extends AppCompatActivity {
 
     private static final String TAG = "SplashActivity";
-    private static final int REQUEST_PERMISSION_CODE = 55;
     private static final int BIOS_REQUEST_CODE = 66;
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_PERMISSION_CODE) {
-            if (permissions.length == 1 && permissions[0].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    initCacheBios();
-                } else {
-                    Toast.makeText(this, "WRITE_EXTERNAL_STORAGE not granted, need to quit", Toast.LENGTH_LONG).show();
-                    this.finishAffinity();
-                }
-            }
-        }
-    }
 
     private void checkOpenGLES20() {
         ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         ConfigurationInfo configurationInfo = am.getDeviceConfigurationInfo();
-        if (configurationInfo.reqGlEsVersion >= 0x20000) {
-            // Supported
-        } else {
+        if (configurationInfo.reqGlEsVersion < 0x20000) {
             new AlertDialog.Builder(this)
                     .setTitle("OpenGLES 2")
                     .setMessage("Your device doesn't support GLES20. reqGLEsVersion = " + configurationInfo.reqGlEsVersion)
@@ -74,21 +51,7 @@ public class SplashActivity extends AppCompatActivity {
         setContentView(R.layout.splash_activity);
 
         checkOpenGLES20();
-
-        if (ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED) {
-
-            // No explanation needed; request the permission
-            ActivityCompat.requestPermissions(this
-                    ,
-                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
-                    REQUEST_PERMISSION_CODE);
-        } else {
-            // Permission has already been granted
-            initCacheBios();
-
-        }
+        initCacheBios();
     }
 
     private void cacheBiosInAppFiles(byte[] bios) throws IOException {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/SplashActivity.java
@@ -75,20 +75,9 @@ public class SplashActivity extends AppCompatActivity {
 
         checkOpenGLES20();
 
-        if (ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED) {
-
-            // No explanation needed; request the permission
-            ActivityCompat.requestPermissions(this
-                    ,
-                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE},
-                    REQUEST_PERMISSION_CODE);
-        } else {
-            // Permission has already been granted
-            initCacheBios();
-
-        }
+        // BIOS/ROM I/O goes through app-private storage (openFileInput/Output) and SAF
+        // (ACTION_OPEN_DOCUMENT) — neither needs WRITE_/READ_EXTERNAL_STORAGE on modern Android.
+        initCacheBios();
     }
 
     private void cacheBiosInAppFiles(byte[] bios) throws IOException {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
@@ -236,8 +236,11 @@ public class RomListActivity extends AppCompatActivity {
 
             }
 
-            this.itemAdapter.notifyDataSetChanged();
-            mGridView.setAdapter(new RomListItemAdapter(this, romManager.getAllRomMetaData()));
+            // The click listener in onCreate captures the `itemAdapter` field, so we must
+            // rebind the field (not just call setAdapter) or taps will read from the old
+            // empty adapter and throw IndexOutOfBoundsException.
+            this.itemAdapter = new RomListItemAdapter(this, romManager.getAllRomMetaData());
+            mGridView.setAdapter(this.itemAdapter);
             mGridView.invalidate();
 
         } else {

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/library/RomListActivity.java
@@ -101,36 +101,36 @@ public class RomListActivity extends AppCompatActivity {
 
         selectedEntry = entry;
 
-        switch (item.getItemId()) {
-            case R.id.action_play:
-                romManager.updateLastPlayed(entry.getId());
-                Util.startEmulator(this, this.bios, entry.getId());
-                this.itemAdapter.notifyDataSetChanged();
-                return true;
-            case R.id.action_delete:
-                romManager.deleteRomMetadata(itemAdapter.getItem(menuInfo.position));
-                return true;
-            case R.id.action_set_screenshot:
-                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-                intent.setType("image/*");
-                intent.putExtra("romId", entry.getId());
-                startActivityForResult(intent, REQUEST_SET_IMAGE);
-                return true;
-            case R.id.action_export_save_file:
-                File backupFile = entry.getBackupFile();
-                try {
-                    Util.shareFile(this, backupFile, "Sending " + backupFile.getName());
-                } catch (FileNotFoundException e) {
-                    Util.showAlertDialog(this, e);
-                }
-                return true;
-            case R.id.action_import_save_file:
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("*/*");
-                startActivityForResult(intent, REQUEST_IMPORT_SAVE);
-                return true;
-            default:
-                return super.onContextItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_play) {
+            romManager.updateLastPlayed(entry.getId());
+            Util.startEmulator(this, this.bios, entry.getId());
+            this.itemAdapter.notifyDataSetChanged();
+            return true;
+        } else if (id == R.id.action_delete) {
+            romManager.deleteRomMetadata(itemAdapter.getItem(menuInfo.position));
+            return true;
+        } else if (id == R.id.action_set_screenshot) {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.setType("image/*");
+            intent.putExtra("romId", entry.getId());
+            startActivityForResult(intent, REQUEST_SET_IMAGE);
+            return true;
+        } else if (id == R.id.action_export_save_file) {
+            File backupFile = entry.getBackupFile();
+            try {
+                Util.shareFile(this, backupFile, "Sending " + backupFile.getName());
+            } catch (FileNotFoundException e) {
+                Util.showAlertDialog(this, e);
+            }
+            return true;
+        } else if (id == R.id.action_import_save_file) {
+            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.setType("*/*");
+            startActivityForResult(intent, REQUEST_IMPORT_SAVE);
+            return true;
+        } else {
+            return super.onContextItemSelected(item);
         }
     }
 
@@ -143,19 +143,19 @@ public class RomListActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.action_import_rom:
-                doImportRom();
-                return true;
-            case R.id.action_import_directory:
-                doImportDirectory();
-                return true;
-            case R.id.action_settings:
-                Intent intent = new Intent(this, SettingsActivity.class);
-                startActivity(intent);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        int id = item.getItemId();
+        if (id == R.id.action_import_rom) {
+            doImportRom();
+            return true;
+        } else if (id == R.id.action_import_directory) {
+            doImportDirectory();
+            return true;
+        } else if (id == R.id.action_settings) {
+            Intent intent = new Intent(this, SettingsActivity.class);
+            startActivity(intent);
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/snapshots/SnapshotListFragment.java
+++ b/platform/android/app/src/main/java/com/mrmichel/rustdroid_emu/ui/snapshots/SnapshotListFragment.java
@@ -64,18 +64,18 @@ public class SnapshotListFragment extends Fragment {
         AdapterView.AdapterContextMenuInfo menuInfo = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
 
         Snapshot snapshot = snapshots.get(menuInfo.position);
-        switch (item.getItemId()) {
-            case R.id.action_delete:
-                SnapshotManager.getInstance(getContext()).deleteSnapshot(snapshot);
-                snapshots.remove(menuInfo.position);
+        int id = item.getItemId();
+        if (id == R.id.action_delete) {
+            SnapshotManager.getInstance(getContext()).deleteSnapshot(snapshot);
+            snapshots.remove(menuInfo.position);
 
-                SnapshotItemAdapter adapter = new SnapshotItemAdapter(getContext(), snapshots);
-                mGridView.setAdapter(adapter);
-                mGridView.invalidate();
+            SnapshotItemAdapter adapter = new SnapshotItemAdapter(getContext(), snapshots);
+            mGridView.setAdapter(adapter);
+            mGridView.invalidate();
 
-                return true;
-            default:
-                return super.onContextItemSelected(item);
+            return true;
+        } else {
+            return super.onContextItemSelected(item);
         }
     }
 

--- a/platform/android/app/src/main/res/menu/menu_emulator.xml
+++ b/platform/android/app/src/main/res/menu/menu_emulator.xml
@@ -36,6 +36,16 @@
         android:title="@string/action_set_library_image" />
 
     <item
+        android:id="@+id/action_record_toggle"
+        android:orderInCategory="200"
+        android:title="@string/action_record_start" />
+
+    <item
+        android:id="@+id/action_replay_toggle"
+        android:orderInCategory="201"
+        android:title="@string/action_replay_start" />
+
+    <item
         android:id="@+id/action_settings"
         android:menuCategory="system"
         android:orderInCategory="100"

--- a/platform/android/app/src/main/res/values/strings.xml
+++ b/platform/android/app/src/main/res/values/strings.xml
@@ -16,6 +16,11 @@
     <string name="action_delete">Delete</string>
     <string name="action_set_library_image"> Take screenshot for library view </string>
 
+    <string name="action_record_start">Start Recording</string>
+    <string name="action_record_stop">Stop Recording</string>
+    <string name="action_replay_start">Start Replay</string>
+    <string name="action_replay_stop">Stop Replay</string>
+
     <string name="title_activity_snapshot">Snapshot Manager</string>
 
     <string name="color_correction_setting">Apply color correction shader</string>

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.9.3'
+        classpath 'org.mozilla.rust-android-gradle:rust-android:0.9.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,29 +3,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
-        
+        classpath 'com.android.tools.build:gradle:8.5.2'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-        
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,15 +3,15 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
-        
+        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.9.3'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -20,8 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
 }
 

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.3'
-        classpath 'org.mozilla.rust-android-gradle:rust-android:0.9.3'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.9.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -17,4 +17,8 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# Keep R.id.* as `static final` so the legacy switch/case statements in this app compile.
+android.nonFinalResIds=false
+# Suppress AGP 8.5's warning about compileSdk=35 being ahead of its tested range.
+android.suppressUnsupportedCompileSdk=35
 

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Feb 22 01:01:17 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip

--- a/platform/android/settings.gradle
+++ b/platform/android/settings.gradle
@@ -1,2 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'
 rootProject.name='RustdroidAdvance'

--- a/platform/rustboyadvance-jni/src/audio/connector.rs
+++ b/platform/rustboyadvance-jni/src/audio/connector.rs
@@ -70,8 +70,12 @@ impl AudioJNIConnector {
             _ => panic!("bad return value"),
         };
 
+        // Size the shared JNI buffer to match the ringbuffer capacity (sample_count * 2,
+        // set in emulator.rs::create_audio). In turbo mode the consumer can pop up to that
+        // many shorts in one go; sizing smaller causes ArrayIndexOutOfBoundsException in
+        // set_short_array_region and crashes the audio worker thread.
         let audio_buffer = env
-            .new_short_array(sample_count as i32)
+            .new_short_array((sample_count * 2) as i32)
             .expect("failed to create sound buffer");
         let audio_buffer_ref = env.new_global_ref(audio_buffer).unwrap();
 

--- a/platform/rustboyadvance-jni/src/emulator.rs
+++ b/platform/rustboyadvance-jni/src/emulator.rs
@@ -2,6 +2,8 @@ use rustboyadvance_core::prelude::*;
 use rustboyadvance_utils::FpsCounter;
 use rustboyadvance_utils::audio::SampleConsumer;
 
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
@@ -139,6 +141,94 @@ fn create_audio(
     ))
 }
 
+/// RBAREC01 file format: magic + (cycle: u64 LE, state: u16 LE) records.
+/// Same format the SDL frontend emits and fps_bench reads.
+const REC_MAGIC: &[u8; 8] = b"RBAREC01";
+
+/// Appends keypad edges to a file as the emulator sees them. Only records
+/// when the state actually changed vs the previous sample so the file stays
+/// small.
+struct Recorder {
+    w: BufWriter<File>,
+    last_state: u16,
+}
+
+impl Recorder {
+    fn open(path: &str) -> std::io::Result<Self> {
+        let f = File::create(path)?;
+        let mut w = BufWriter::new(f);
+        w.write_all(REC_MAGIC)?;
+        Ok(Recorder { w, last_state: 0 })
+    }
+
+    /// Called once per frame with the current keypad state and the
+    /// emulator's cycle counter. Writes a record only on an edge.
+    fn observe(&mut self, cycle: u64, state: u16) -> std::io::Result<()> {
+        if state == self.last_state {
+            return Ok(());
+        }
+        self.w.write_all(&cycle.to_le_bytes())?;
+        self.w.write_all(&state.to_le_bytes())?;
+        self.last_state = state;
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.w.flush()
+    }
+}
+
+/// Plays back a recording against the emulator. `apply_due` returns the
+/// state the emulator should use for the upcoming frame, overriding
+/// whatever the Java keypad says.
+struct Replayer {
+    events: Vec<(u64, u16)>, // (cycle, state)
+    cursor: usize,
+    current_state: u16,
+}
+
+impl Replayer {
+    fn load(path: &str) -> std::io::Result<Self> {
+        let mut f = File::open(path)?;
+        let mut magic = [0u8; 8];
+        f.read_exact(&mut magic)?;
+        if &magic != REC_MAGIC {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "recording magic mismatch",
+            ));
+        }
+        let mut events = Vec::new();
+        let mut buf = [0u8; 10];
+        loop {
+            match f.read_exact(&mut buf) {
+                Ok(()) => {
+                    let c = u64::from_le_bytes(buf[0..8].try_into().unwrap());
+                    let s = u16::from_le_bytes(buf[8..10].try_into().unwrap());
+                    events.push((c, s));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(Replayer { events, cursor: 0, current_state: 0 })
+    }
+
+    /// Advance through events whose cycle has already passed, letting
+    /// later events win. Returns the state to hand to the emulator.
+    fn apply_due(&mut self, now: u64) -> u16 {
+        while self.cursor < self.events.len() && self.events[self.cursor].0 <= now {
+            self.current_state = self.events[self.cursor].1;
+            self.cursor += 1;
+        }
+        self.current_state
+    }
+
+    fn exhausted(&self) -> bool {
+        self.cursor >= self.events.len()
+    }
+}
+
 pub struct EmulatorContext {
     audio_consumer: Option<SampleConsumer>,
     renderer: Renderer,
@@ -146,6 +236,12 @@ pub struct EmulatorContext {
     keypad: Keypad,
     pub emustate: Mutex<EmulationState>,
     pub gba: GameBoyAdvance,
+    /// On-device keypad recorder. When Some, every frame writes an edge
+    /// record to the backing file. None means no recording.
+    recorder: Mutex<Option<Recorder>>,
+    /// On-device keypad replayer. When Some, every frame overrides the
+    /// keypad state with the replayer's next event.
+    replayer: Mutex<Option<Replayer>>,
 }
 
 impl EmulatorContext {
@@ -201,6 +297,8 @@ impl EmulatorContext {
             audio_player_ref,
             emustate: Mutex::new(EmulationState::default()),
             audio_consumer: Some(audio_consumer),
+            recorder: Mutex::new(None),
+            replayer: Mutex::new(None),
         };
         Ok(context)
     }
@@ -246,6 +344,8 @@ impl EmulatorContext {
             audio_player_ref,
             emustate: Mutex::new(EmulationState::default()),
             audio_consumer: Some(audio_consumer),
+            recorder: Mutex::new(None),
+            replayer: Mutex::new(None),
         })
     }
 
@@ -300,8 +400,23 @@ impl EmulatorContext {
             };
 
             let start_time = Instant::now();
-            // check key state
-            *self.gba.get_key_state_mut() = self.keypad.get_key_state(env);
+            // check key state: live from the Java keypad unless a replay
+            // session is active, in which case the replay file overrides.
+            let live_state = self.keypad.get_key_state(env);
+            let gba_cycles = self.gba.cycles() as u64;
+            let effective_state = {
+                let mut replayer = self.replayer.lock().unwrap();
+                if let Some(r) = replayer.as_mut() {
+                    r.apply_due(gba_cycles)
+                } else {
+                    live_state
+                }
+            };
+            *self.gba.get_key_state_mut() = effective_state;
+            // If recording, log any edge the emulator saw this frame.
+            if let Some(rec) = self.recorder.lock().unwrap().as_mut() {
+                let _ = rec.observe(gba_cycles, effective_state);
+            }
 
             // run frame
             self.gba.frame();
@@ -376,6 +491,48 @@ impl EmulatorContext {
 
     pub fn set_turbo(&mut self, turbo: bool) {
         *self.emustate.lock().unwrap() = EmulationState::Running(turbo);
+    }
+
+    /// Begin recording keypad edges to the file at `path`. Overwrites any
+    /// existing recording. Stops and discards an active replay session.
+    pub fn start_recording(&self, path: &str) -> Result<(), String> {
+        *self.replayer.lock().unwrap() = None;
+        match Recorder::open(path) {
+            Ok(r) => {
+                *self.recorder.lock().unwrap() = Some(r);
+                info!("recording keypad to {}", path);
+                Ok(())
+            }
+            Err(e) => Err(format!("could not open {} for recording: {}", path, e)),
+        }
+    }
+
+    /// Flushes and closes the active recorder, if any.
+    pub fn stop_recording(&self) {
+        if let Some(mut r) = self.recorder.lock().unwrap().take() {
+            let _ = r.flush();
+            info!("recording stopped");
+        }
+    }
+
+    /// Load a recording from `path` and start feeding its events into the
+    /// emulator. Stops any active recording session first.
+    pub fn start_replay(&self, path: &str) -> Result<(), String> {
+        *self.recorder.lock().unwrap() = None;
+        match Replayer::load(path) {
+            Ok(r) => {
+                info!("replaying {} events from {}", r.events.len(), path);
+                *self.replayer.lock().unwrap() = Some(r);
+                Ok(())
+            }
+            Err(e) => Err(format!("could not open {} for replay: {}", path, e)),
+        }
+    }
+
+    /// Stop an active replay session.
+    pub fn stop_replay(&self) {
+        let _ = self.replayer.lock().unwrap().take();
+        info!("replay stopped");
     }
 
     pub fn request_stop(&mut self) {

--- a/platform/rustboyadvance-jni/src/emulator.rs
+++ b/platform/rustboyadvance-jni/src/emulator.rs
@@ -415,8 +415,18 @@ impl EmulatorContext {
             };
             *self.gba.get_key_state_mut() = effective_state;
             // If recording, log any edge the emulator saw this frame.
-            if let Some(rec) = self.recorder.lock().unwrap().as_mut() {
-                let _ = rec.observe(gba_cycles, effective_state);
+            // On the first IO error (disk full, sandbox revoked the file
+            // handle, etc), drop the recorder so we stop trying to write
+            // every frame; otherwise we'd silently log forever while the
+            // user thinks recording is still going.
+            {
+                let mut rec_guard = self.recorder.lock().unwrap();
+                if let Some(rec) = rec_guard.as_mut() {
+                    if let Err(e) = rec.observe(gba_cycles, effective_state) {
+                        log::warn!("recorder write failed, stopping recording: {}", e);
+                        *rec_guard = None;
+                    }
+                }
             }
 
             // run frame

--- a/platform/rustboyadvance-jni/src/emulator.rs
+++ b/platform/rustboyadvance-jni/src/emulator.rs
@@ -181,6 +181,7 @@ impl Recorder {
 /// Plays back a recording against the emulator. `apply_due` returns the
 /// state the emulator should use for the upcoming frame, overriding
 /// whatever the Java keypad says.
+#[cfg_attr(test, derive(Debug))]
 struct Replayer {
     events: Vec<(u64, u16)>, // (cycle, state)
     cursor: usize,
@@ -543,5 +544,111 @@ impl EmulatorContext {
 
     pub fn is_stopped(&self) -> bool {
         *self.emustate.lock().unwrap() == EmulationState::Stopped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_path(name: &str) -> String {
+        let dir = std::env::temp_dir();
+        dir.join(format!("rba-recorder-test-{}-{}.rec",
+                         name, std::process::id())).to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn record_then_replay_round_trips_edges() {
+        let path = tmp_path("edges");
+        let mut rec = Recorder::open(&path).expect("open for write");
+        // Observe a sequence of states with idle duplicates; only edges
+        // should land on disk.
+        rec.observe(100, 0x01).unwrap();
+        rec.observe(200, 0x01).unwrap(); // duplicate, skipped
+        rec.observe(300, 0x03).unwrap();
+        rec.observe(400, 0x00).unwrap();
+        rec.observe(500, 0x00).unwrap(); // duplicate, skipped
+        rec.flush().unwrap();
+        drop(rec);
+
+        let mut rp = Replayer::load(&path).expect("open for read");
+        assert_eq!(rp.events.len(), 3);
+        assert_eq!(rp.events[0], (100, 0x01));
+        assert_eq!(rp.events[1], (300, 0x03));
+        assert_eq!(rp.events[2], (400, 0x00));
+
+        // apply_due semantics: the latest event whose cycle has passed wins.
+        assert_eq!(rp.apply_due(50),  0x00); // before first event -> initial 0
+        assert_eq!(rp.apply_due(150), 0x01);
+        assert_eq!(rp.apply_due(250), 0x01); // no new event yet
+        assert_eq!(rp.apply_due(350), 0x03); // reached second event
+        assert_eq!(rp.apply_due(450), 0x00); // reached third event
+        assert!(rp.exhausted());
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn replay_rejects_bad_magic() {
+        let path = tmp_path("badmagic");
+        std::fs::write(&path, b"NOTAREC\0\0\0\0\0\0\0\0\0\0").unwrap();
+        let err = Replayer::load(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn replay_handles_empty_recording() {
+        let path = tmp_path("empty");
+        let mut rec = Recorder::open(&path).expect("open");
+        rec.flush().unwrap();
+        drop(rec);
+
+        let mut rp = Replayer::load(&path).expect("open");
+        assert_eq!(rp.events.len(), 0);
+        assert!(rp.exhausted());
+        // apply_due on empty replayer returns initial 0.
+        assert_eq!(rp.apply_due(100), 0);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn record_out_of_order_states_preserved() {
+        // Even if the emulator's get_key_state returns values that
+        // "undo" themselves quickly, the recorder captures every edge
+        // so replay matches execution.
+        let path = tmp_path("flicker");
+        let mut rec = Recorder::open(&path).unwrap();
+        rec.observe(10, 0x02).unwrap();
+        rec.observe(20, 0x00).unwrap();
+        rec.observe(30, 0x02).unwrap();
+        rec.observe(40, 0x00).unwrap();
+        rec.flush().unwrap();
+        drop(rec);
+
+        let rp = Replayer::load(&path).unwrap();
+        assert_eq!(rp.events.len(), 4);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn round_trip_binary_compatible_with_fps_bench_format() {
+        // The on-device Recorder must write the exact same byte layout
+        // the desktop SDL frontend emits and fps_bench's replay module
+        // reads, so recordings are portable either direction.
+        let path = tmp_path("format");
+        let mut rec = Recorder::open(&path).unwrap();
+        rec.observe(0x1111_2222_3333_4444, 0xBEEF).unwrap();
+        rec.flush().unwrap();
+        drop(rec);
+
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(&raw[0..8], b"RBAREC01");
+        // cycle: u64 LE, state: u16 LE
+        let cycle = u64::from_le_bytes(raw[8..16].try_into().unwrap());
+        let state = u16::from_le_bytes(raw[16..18].try_into().unwrap());
+        assert_eq!(cycle, 0x1111_2222_3333_4444);
+        assert_eq!(state, 0xBEEF);
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/platform/rustboyadvance-jni/src/emulator.rs
+++ b/platform/rustboyadvance-jni/src/emulator.rs
@@ -1,6 +1,6 @@
 use rustboyadvance_core::prelude::*;
+use rustboyadvance_utils::FpsCounter;
 use rustboyadvance_utils::audio::SampleConsumer;
-// use rustboyadvance_core::util::FpsCounter;
 
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
@@ -281,7 +281,7 @@ impl EmulatorContext {
 
         info!("starting main emulation loop");
 
-        // let mut fps_counter = FpsCounter::default();
+        let mut fps_counter = FpsCounter::default();
 
         'running: loop {
             let emustate = *self.emustate.lock().unwrap();
@@ -314,9 +314,11 @@ impl EmulatorContext {
                 .send(AudioThreadCommand::RenderAudio)
                 .unwrap();
 
-            // if let Some(fps) = fps_counter.tick() {
-            //     info!("FPS {}", fps);
-            // }
+            // Emit one log line per second with the measured FPS. Use the
+            // LCD tag so `adb logcat -s RustdroidFps` filters cleanly.
+            if let Some(fps) = fps_counter.tick() {
+                info!(target: "RustdroidFps", "FPS {}", fps);
+            }
 
             if vsync {
                 let time_passed = start_time.elapsed();

--- a/platform/rustboyadvance-jni/src/lib.rs
+++ b/platform/rustboyadvance-jni/src/lib.rs
@@ -211,20 +211,28 @@ pub mod bindings {
         while !ctx.is_stopped() {}
     }
 
+    /// Returns 1 on success, 0 on any failure (bad path, file open error,
+    /// IO error, etc). Java side must check the return and only flip its
+    /// "isRecording" UI state when 1 — otherwise the toast and menu label
+    /// would lie about a recording that never started.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_startRecording(
         mut env: JNIEnv,
         _obj: JClass,
         ctx: jlong,
         path: JString,
-    ) {
+    ) -> jboolean {
         let ctx = unsafe { cast_ctx(ctx) };
         let path_rs: String = match env.get_string(&path) {
             Ok(s) => s.into(),
-            Err(_) => { log::warn!("startRecording: bad path string"); return; }
+            Err(_) => { log::warn!("startRecording: bad path string"); return 0; }
         };
-        if let Err(e) = ctx.start_recording(&path_rs) {
-            log::warn!("startRecording failed: {}", e);
+        match ctx.start_recording(&path_rs) {
+            Ok(()) => 1,
+            Err(e) => {
+                log::warn!("startRecording failed: {}", e);
+                0
+            }
         }
     }
 
@@ -238,20 +246,27 @@ pub mod bindings {
         ctx.stop_recording();
     }
 
+    /// Returns 1 on success, 0 on any failure (bad path, file open error,
+    /// magic mismatch, IO error, etc). Same lying-toast caveat as
+    /// startRecording — Java must check the return.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_startReplay(
         mut env: JNIEnv,
         _obj: JClass,
         ctx: jlong,
         path: JString,
-    ) {
+    ) -> jboolean {
         let ctx = unsafe { cast_ctx(ctx) };
         let path_rs: String = match env.get_string(&path) {
             Ok(s) => s.into(),
-            Err(_) => { log::warn!("startReplay: bad path string"); return; }
+            Err(_) => { log::warn!("startReplay: bad path string"); return 0; }
         };
-        if let Err(e) = ctx.start_replay(&path_rs) {
-            log::warn!("startReplay failed: {}", e);
+        match ctx.start_replay(&path_rs) {
+            Ok(()) => 1,
+            Err(e) => {
+                log::warn!("startReplay failed: {}", e);
+                0
+            }
         }
     }
 

--- a/platform/rustboyadvance-jni/src/lib.rs
+++ b/platform/rustboyadvance-jni/src/lib.rs
@@ -212,6 +212,60 @@ pub mod bindings {
     }
 
     #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_startRecording(
+        mut env: JNIEnv,
+        _obj: JClass,
+        ctx: jlong,
+        path: JString,
+    ) {
+        let ctx = unsafe { cast_ctx(ctx) };
+        let path_rs: String = match env.get_string(&path) {
+            Ok(s) => s.into(),
+            Err(_) => { log::warn!("startRecording: bad path string"); return; }
+        };
+        if let Err(e) = ctx.start_recording(&path_rs) {
+            log::warn!("startRecording failed: {}", e);
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_stopRecording(
+        _env: JNIEnv,
+        _obj: JClass,
+        ctx: jlong,
+    ) {
+        let ctx = unsafe { cast_ctx(ctx) };
+        ctx.stop_recording();
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_startReplay(
+        mut env: JNIEnv,
+        _obj: JClass,
+        ctx: jlong,
+        path: JString,
+    ) {
+        let ctx = unsafe { cast_ctx(ctx) };
+        let path_rs: String = match env.get_string(&path) {
+            Ok(s) => s.into(),
+            Err(_) => { log::warn!("startReplay: bad path string"); return; }
+        };
+        if let Err(e) = ctx.start_replay(&path_rs) {
+            log::warn!("startReplay failed: {}", e);
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_stopReplay(
+        _env: JNIEnv,
+        _obj: JClass,
+        ctx: jlong,
+    ) {
+        let ctx = unsafe { cast_ctx(ctx) };
+        ctx.stop_replay();
+    }
+
+    #[unsafe(no_mangle)]
     pub unsafe extern "C" fn Java_com_mrmichel_rustboyadvance_EmulatorBindings_getFrameBuffer(
         env: JNIEnv,
         _obj: JClass,


### PR DESCRIPTION
Split out of #195. On-device record/replay for the Android APK — record your gameplay inputs to a file on `/sdcard/Download/`, pull with adb, replay against any fps_bench or APK build. Perf benchmarks that were reproducible down to the exact emulated cycle.

**Depends on #194** (Android build modernization). Should be reviewed/merged after #194 since it touches `EmulatorActivity.java` with the AGP 8.x compatible switch style.

## What's in here

4 commits:

1. **`jni: log per-second FPS from emulation main loop`** — adds a small FpsCounter in the emulation loop so `adb logcat -s RustdroidFps:I` shows per second FPS. Only meaningful under turbo mode (vsync off).
2. **`core: expose GameBoyAdvance::cycles() for record/replay timing`** — one line helper returning the scheduler's current cycle timestamp. The record/replay layer uses it to stamp keypad edges so playback lines up at the exact cycle the input was originally captured.
3. **`jni: on device keypad record + replay in the APK`** — the main feature. Two menu items in the emulator activity toggle recording and replay against `/sdcard/Download/rbarec.rec`. File format is the same `RBAREC01` header + `(cycle:u64 LE, state:u16 LE)` records as the SDL frontend/fps_bench, so it's fully interoperable: record on device, replay in fps_bench on desktop, and vice versa. Recorder writes edges only (state actually changed) so file size scales with input events not frames. Replay uses latest event wins semantics: every event whose cycle is already behind the emulator's current cycle is applied; the last one wins.
4. **`jni: unit tests for APK Recorder / Replayer round-trip`** — 5 unit tests covering: happy path round trip, bad magic bytes rejected, empty file produces empty replayer, edge-only encoding produces no output when state doesn't change, binary format is identical to fps_bench. `cargo test --release -p rustboyadvance-jni` → 5 passed.

## What's *not* in here

- The SDL frontend's own record/replay (9efaf42 on #195 adds that via `--record-input` + `--replay` flags; if you want that I'll split it as a separate tiny PR)
- Per frame phase timing instrumentation (experiment, reverted on #195)
- Frame skip in turbo mode (experiment, kept on #195 for A/B but not strictly needed)

## Verification

- JNI Rust: `cargo test --release -p rustboyadvance-jni` → 5 passed
- On device: recorded a 256 second pokeemerald session (title → overworld → menus → battles), replayed at the exact same cycle count (4,299,434,505) on three different builds — deterministic to the cycle
- File format: `rbarec.rec` recorded via the APK opens cleanly in fps_bench `--replay`, bench runs produce the same FPS whether the rec came from device or desktop