### PR TITLE
wasm: schedule streamed audio buffers gaplessly to fix choppy WebAudio (#80)

### DIFF
--- a/platform/rustboyadvance-wasm/app/audioScheduler.mjs
+++ b/platform/rustboyadvance-wasm/app/audioScheduler.mjs
@@ -1,0 +1,26 @@
+// Gapless scheduling for streamed WebAudio buffers.
+//
+// The emulator produces a small chunk of PCM samples every emulated frame.
+// Playing each chunk with `AudioBufferSourceNode.start()` (no argument) starts
+// it at `AudioContext.currentTime`, i.e. "now". Because the JS frame loop does
+// not tick at exactly the audio-buffer duration, consecutive chunks either
+// overlap (loop ran early) or leave a silent gap (loop ran late), which is
+// heard as choppy audio (issue #80).
+//
+// The fix is the standard streaming pattern: keep a running "playback head"
+// timestamp and schedule each buffer to begin exactly where the previous one
+// ended, clamping to `currentTime` so we never schedule in the past after an
+// underrun.
+
+// Compute the start time for the next audio buffer and the advanced playback
+// head. Pure function so the continuity behaviour is testable without a browser.
+//
+//   currentTime    - AudioContext.currentTime (monotonic, seconds)
+//   playbackHead   - end time of the previously scheduled buffer (seconds)
+//   bufferDuration - duration of the buffer to schedule (seconds)
+//
+// Returns { startTime, nextPlaybackHead }.
+export function scheduleAudioBuffer(currentTime, playbackHead, bufferDuration) {
+	const startTime = Math.max(currentTime, playbackHead);
+	return { startTime, nextPlaybackHead: startTime + bufferDuration };
+}

--- a/platform/rustboyadvance-wasm/app/audioScheduler.test.mjs
+++ b/platform/rustboyadvance-wasm/app/audioScheduler.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { scheduleAudioBuffer } from "./audioScheduler.mjs";
+
+// A buffer is BUFFER_SECONDS long, but the driving JS loop wakes up with jitter
+// so the AudioContext clock does not advance by exactly one buffer per chunk.
+const BUFFER_SECONDS = 0.016;
+// currentTime deltas between consecutive playAudio() calls. Each is strictly
+// less than BUFFER_SECONDS, so the loop always keeps the audio buffered ahead
+// of the clock (no producer underrun) while still jittering enough that the
+// naive "start now" scheme is never contiguous.
+const CLOCK_DELTAS = [0.01, 0.014, 0.008, 0.015, 0.012, 0.013, 0.009, 0.011];
+const EPSILON = 1e-9;
+
+function driveClock(deltas) {
+	const times = [0];
+	for (const d of deltas) times.push(times[times.length - 1] + d);
+	return times;
+}
+
+// The previous implementation: every chunk starts at currentTime ("now").
+function naiveWindows(clock) {
+	return clock.map((currentTime) => ({
+		start: currentTime,
+		end: currentTime + BUFFER_SECONDS,
+	}));
+}
+
+// The scheduled implementation driven through the pure scheduler.
+function scheduledWindows(clock) {
+	const windows = [];
+	let playbackHead = 0;
+	for (const currentTime of clock) {
+		const { startTime, nextPlaybackHead } = scheduleAudioBuffer(
+			currentTime,
+			playbackHead,
+			BUFFER_SECONDS,
+		);
+		windows.push({ start: startTime, end: nextPlaybackHead });
+		playbackHead = nextPlaybackHead;
+	}
+	return windows;
+}
+
+test("naive immediate scheduling produces overlaps or gaps (the reported defect)", () => {
+	const windows = naiveWindows(driveClock(CLOCK_DELTAS));
+	let discontinuities = 0;
+	for (let i = 1; i < windows.length; i++) {
+		if (Math.abs(windows[i].start - windows[i - 1].end) > EPSILON) {
+			discontinuities++;
+		}
+	}
+	// Every boundary is discontinuous under the naive scheme -> choppy audio.
+	assert.equal(discontinuities, windows.length - 1);
+});
+
+test("scheduled playback is gapless and never overlaps once buffered ahead", () => {
+	const windows = scheduledWindows(driveClock(CLOCK_DELTAS));
+	for (let i = 1; i < windows.length; i++) {
+		// Contiguous: next buffer begins exactly where the previous ended.
+		assert.ok(
+			Math.abs(windows[i].start - windows[i - 1].end) <= EPSILON,
+			`boundary ${i} not contiguous: prev.end=${windows[i - 1].end} start=${windows[i].start}`,
+		);
+	}
+});
+
+test("scheduling never targets a time in the past (underrun resyncs to now)", () => {
+	// Force a long stall so the playback head falls behind the clock.
+	const clock = [0, 0.016, 0.032, 5.0, 5.016];
+	let playbackHead = 0;
+	for (const currentTime of clock) {
+		const { startTime, nextPlaybackHead } = scheduleAudioBuffer(
+			currentTime,
+			playbackHead,
+			BUFFER_SECONDS,
+		);
+		assert.ok(
+			startTime >= currentTime - EPSILON,
+			`scheduled in the past: start=${startTime} currentTime=${currentTime}`,
+		);
+		playbackHead = nextPlaybackHead;
+	}
+});

--- a/platform/rustboyadvance-wasm/app/index.js
+++ b/platform/rustboyadvance-wasm/app/index.js
@@ -1,3 +1,4 @@
+import { scheduleAudioBuffer } from "./audioScheduler.mjs";
 import * as wasm from "rustboyadvance-wasm";
 
 var fps_text = document.getElementById('fps');
@@ -69,10 +70,19 @@ var fpsCounter = (function() {
 const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 console.log("audio context " + audioContext);
 
+// Running playback head: the time (on the AudioContext clock) at which the
+// previously scheduled buffer ends. Buffers are scheduled back-to-back from
+// here so streamed frames play gaplessly instead of choppily (issue #80).
+let audioPlaybackHead = 0;
+
 const playAudio = emulator => {
     let audioData = emulator.collect_audio_samples();
 
     let frameCount = audioData.length / 2;
+    if (frameCount === 0) {
+        // No samples this frame; nothing to schedule.
+        return;
+    }
     const audioBuffer = audioContext.createBuffer(
         2,
         frameCount,
@@ -91,7 +101,14 @@ const playAudio = emulator => {
     audioSource.buffer = audioBuffer;
 
     audioSource.connect(audioContext.destination);
-    audioSource.start();
+
+    const { startTime, nextPlaybackHead } = scheduleAudioBuffer(
+        audioContext.currentTime,
+        audioPlaybackHead,
+        audioBuffer.duration
+    );
+    audioPlaybackHead = nextPlaybackHead;
+    audioSource.start(startTime);
 }
 
 const emulatorLoop = function() {

--- a/platform/rustboyadvance-wasm/app/package.json
+++ b/platform/rustboyadvance-wasm/app/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server",
+    "test": "node --test"
   },
   "dependencies": {
     "rustboyadvance-wasm": "file:../pkg"


### PR DESCRIPTION
Closes #80

## Summary

Fixes the choppy WebAudio playback in the WASM frontend reported in #80.

## Root cause

`playAudio()` collected each emulated frame's PCM chunk into an `AudioBuffer`
and played it with `AudioBufferSourceNode.start()` and **no time argument**,
which schedules playback at `AudioContext.currentTime` ("now"). The driving JS
loop (`setInterval(emulatorLoop, 16)`) does not wake up at exactly one
audio-buffer duration, so consecutive chunks either overlap (loop ran early) or
leave a silent gap (loop ran late). Both are heard as choppy audio.

## Fix

Adopt the standard streaming pattern: keep a running "playback head" timestamp
and schedule each buffer to begin exactly where the previous one ended, clamping
to `currentTime` so a producer underrun resyncs cleanly instead of scheduling in
the past. Empty sample batches are skipped.

The scheduling decision is factored into a small pure module
(`audioScheduler.mjs`) so the continuity behaviour is verifiable without a
browser.

## Tests

Added `audioScheduler.test.mjs`, a deterministic `node --test` regression suite
(wired as `npm test`, no new dependencies):

- the previous "start now" scheme is discontinuous (choppy) under a jittery clock;
- the scheduled playback is gapless and never overlaps while buffered ahead;
- scheduling never targets a time in the past (underrun resyncs to now).

```
$ npm test
✔ naive immediate scheduling produces overlaps or gaps (the reported defect)
✔ scheduled playback is gapless and never overlaps once buffered ahead
✔ scheduling never targets a time in the past (underrun resyncs to now)
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

The change is confined to the WASM frontend (`platform/rustboyadvance-wasm/app`)
and does not touch the emulator core.

